### PR TITLE
Change DSet.Fold to use state separately per Parition. 

### DIFF
--- a/src/CoreLib/DKV.fs
+++ b/src/CoreLib/DKV.fs
@@ -85,7 +85,7 @@ type DKV<'K, 'V when 'K : equality> =
             else
                 null
         let d = x |> DSet.cacheInMemory |> DSet.map (fun (k, v) -> k )
-        let set = d.Fold(foldFunc, aggrFunc, null)
+        let set = d.FoldWithCommonStatePerNode(foldFunc, aggrFunc, null)
         let dic = Dictionary<_,_>()
         let npart = ref 0
         for k in set do 

--- a/src/CoreLib/DSetAction.fs
+++ b/src/CoreLib/DSetAction.fs
@@ -404,6 +404,7 @@ type internal DSetFoldAction<'U, 'State >()=
     member val AggreFunc: AggregateFunction = null with get, set
     member val GVSerializeFunc = GVSerialize<'State>()
     member val InitialParam = None  with get, set
+    member val CommonStatePerNode = false with get, set
     member x.DoFold( s: 'State ) = 
         if x.ParameterList.Count<>1 then 
             let msg = sprintf "DSetFoldAction should take a single DSet parameter, while %d parameters are given" x.ParameterList.Count
@@ -451,6 +452,7 @@ type internal DSetFoldAction<'U, 'State >()=
         msPayload.WriteVInt32( peeriPartitionArray.Length )
         for parti in peeriPartitionArray do 
             msPayload.WriteVInt32( parti )
+        msPayload.WriteBoolean( x.CommonStatePerNode )
         msPayload.Serialize( x.FoldFunc ) // Don't use Serialize From
         msPayload.Serialize( x.AggreFunc )
         msPayload.Serialize( x.GVSerializeFunc )

--- a/src/CoreLib/DSetCSharp.fs
+++ b/src/CoreLib/DSetCSharp.fs
@@ -154,14 +154,26 @@ type DSet<'U> () =
         x.DSet.ToSeq()
 
     /// <summary>
-    /// Fold the entire DSet with a fold function, an aggregation function, and an initial state. The initial state is broadcasted to each partition. 
+    /// Fold the entire DSet with a fold function, an aggregation function, and an initial state. The initial state is broadcasted to each node, 
+    /// and shared across partition within the node.  
     /// Within each partition, the elements are folded into the state variable using 'folder' function. Then 'aggrFunc' is used to aggregate the resulting
     /// state variables from all partitions to a single state.
     /// </summary>
     /// <param name="folder"> update the state given the input elements </param>
     /// <param name="aggrFunc"> aggregate the state from different partitions to a single state variable.</param>
     /// <param name="state"> initial state for each partition </param>
-    member x.Fold (folder : Func<'State, 'U, 'State>, aggrFunc : Func<'State, 'State, 'State>, state : 'State) = 
+    member private x.FoldWithCommonStatePerNode (folder : Func<'State, 'U, 'State>, aggrFunc : Func<'State, 'State, 'State>, state : 'State) = 
+        x.DSet.FoldWithCommonStatePerNode(folder.ToFSharpFunc(), aggrFunc.ToFSharpFunc(), state)
+
+    /// <summary>
+    /// Fold the entire DSet with a fold function, an aggregation function, and an initial state. The initial state is deserialized (separately) for each partition. 
+    /// Within each partition, the elements are folded into the state variable using 'folder' function. Then 'aggrFunc' is used to aggregate the resulting
+    /// state variables from all partitions to a single state.
+    /// </summary>
+    /// <param name="folder"> update the state given the input elements </param>
+    /// <param name="aggrFunc"> aggregate the state from different partitions to a single state variable.</param>
+    /// <param name="state"> initial state for each partition </param>
+    member private x.Fold (folder : Func<'State, 'U, 'State>, aggrFunc : Func<'State, 'State, 'State>, state : 'State) = 
         x.DSet.Fold(folder.ToFSharpFunc(), aggrFunc.ToFSharpFunc(), state)
 
     /// <summary>

--- a/tests/Examples/Examples.fs
+++ b/tests/Examples/Examples.fs
@@ -6,6 +6,7 @@ open NUnit.Framework
 
 open Prajna.Test.Common
 open Prajna.Examples.Common
+open Prajna.Tools.FSharp
 
 [<TestFixture(Description = "Tests for Examples")>]
 type ExamplesTests() = 
@@ -34,6 +35,7 @@ type ExamplesTests() =
     [<Test(Description = "Test for FSharp Examples")>]
     [<TestCaseSource("FSharpExamples")>]
     member x.FSharpExamplesTest(example : IExample) =
+        Logger.LogF( LogLevel.MildVerbose, fun _ -> "Start F# samples"  )
         let ret = example.Run(sharedCluster)
         Assert.IsTrue(ret)
 


### PR DESCRIPTION
The pull request address issue #12.

Change DSet.Fold to use state separately deserialized per partition. A FoldWithCommonStatePerNode is retained for internal implementation that takes advantage of common state per node. 
