### PR TITLE
Measure test time, kill hanging nunit-agent.exe, and fix data drive selection when there's only a single drive

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,9 @@ build_script:
   - cmd: build.cmd Release
 test: off
 version: 0.0.1.{build}
-artifacts:
-  - path: bin
-    name: bin
 
-# on build failure
+# on the build failure
 on_failure:
   - ps: $root = Resolve-Path C:\OneNet\Log; [IO.Directory]::GetFiles($root.Path, '*.*', 'AllDirectories') | % { Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1) -DeploymentName to-publish }
+
+

--- a/tests/CoreLib/DKV.fs
+++ b/tests/CoreLib/DKV.fs
@@ -31,15 +31,19 @@ type DKVTests () =
         (DSet<_> ( Name = defaultDKVName, Cluster = cluster, NumReplications = 1))
         |> DSet.sourceI defaultDKVNumPartitions ( fun i -> seq { for j in 0..(numDKVsPerPartitionForDefaultDKV-1) do yield (i, (j, (sprintf "%i" j))) } )
 
+    let sw = Diagnostics.Stopwatch()
+
     // To be called before each test
     [<SetUp>] 
     member x.InitTest () =
+        sw.Start()
         Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "##### Test %s starts (%s) #####" TestContext.CurrentContext.Test.FullName (StringTools.UtcNowToString())))
 
     // To be called right after each test
     [<TearDown>] 
     member x.CleanUpTest () =
-        Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "##### Test %s ends (%s): %s #####" TestContext.CurrentContext.Test.FullName (StringTools.UtcNowToString()) (TestContext.CurrentContext.Result.Status.ToString())))
+        sw.Stop()
+        Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "##### Test %s ends (%s): %s (%i ms) #####" TestContext.CurrentContext.Test.FullName (StringTools.UtcNowToString()) (TestContext.CurrentContext.Result.Status.ToString()) sw.ElapsedMilliseconds))
 
 
     [<Test(Description = "Test for DKV.filterByKey")>]

--- a/tests/CoreLib/DSet.fs
+++ b/tests/CoreLib/DSet.fs
@@ -29,15 +29,19 @@ type DSetTests () =
         (DSet<_> ( Name = defaultDsetName, Cluster = cluster, NumReplications = 1)) 
         |> DSet.sourceI defaultDSetSize ( fun i -> seq { yield i } )
 
+    let sw = Diagnostics.Stopwatch()
+
     // To be called before each test
     [<SetUp>] 
     member x.InitTest () =
+        sw.Start()
         Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "##### Test %s starts (%s) #####" TestContext.CurrentContext.Test.FullName (StringTools.UtcNowToString())))
 
     // To be called right after each test
     [<TearDown>] 
     member x.CleanUpTest () =
-        Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "##### Test %s ends (%s): %s #####" TestContext.CurrentContext.Test.FullName (StringTools.UtcNowToString()) (TestContext.CurrentContext.Result.Status.ToString())))
+        sw.Stop()
+        Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "##### Test %s ends (%s): %s (%i ms) #####" TestContext.CurrentContext.Test.FullName (StringTools.UtcNowToString()) (TestContext.CurrentContext.Result.Status.ToString()) sw.ElapsedMilliseconds))
 
     [<Test(Description = "Test for DSet.identity")>]
     member x.DSetIdentityTest() =

--- a/tests/CoreLib/service.fs
+++ b/tests/CoreLib/service.fs
@@ -44,15 +44,19 @@ type CoreServiceTests () =
     let cluster = TestSetup.SharedCluster
     let clusterSize = TestSetup.SharedClusterSize   
 
+    let sw = Diagnostics.Stopwatch()
+
     // To be called before each test
     [<SetUp>] 
     member x.InitTest () =
+        sw.Start()
         Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "##### Test %s starts (%s) #####" TestContext.CurrentContext.Test.FullName (StringTools.UtcNowToString())))
 
     // To be called right after each test
     [<TearDown>] 
     member x.CleanUpTest () =
-        Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "##### Test %s ends (%s): %s #####" TestContext.CurrentContext.Test.FullName (StringTools.UtcNowToString()) (TestContext.CurrentContext.Result.Status.ToString())))
+        sw.Stop()
+        Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "##### Test %s ends (%s): %s (%i ms) #####" TestContext.CurrentContext.Test.FullName (StringTools.UtcNowToString()) (TestContext.CurrentContext.Result.Status.ToString()) sw.ElapsedMilliseconds))
 
     [<Test(Description = "Start a service remotely")>]
     member x.PrajnaInstanceStart() =

--- a/tests/Examples/Examples.fs
+++ b/tests/Examples/Examples.fs
@@ -4,12 +4,16 @@ open System
 open System.Reflection
 open NUnit.Framework
 
+open Prajna.Tools
+open Prajna.Tools.FSharp
+
 open Prajna.Test.Common
 open Prajna.Examples.Common
 
 [<TestFixture(Description = "Tests for Examples")>]
 type ExamplesTests() = 
     let sharedCluster = TestEnvironment.Environment.Value.LocalCluster
+    let sw = Diagnostics.Stopwatch()
 
     // specifiy one of the types that is defined in the assembly to help find all the IExample test cases in the assembly
     static let findTestCases t =
@@ -29,6 +33,19 @@ type ExamplesTests() =
     // This is the source of test cases for Test x.CSharpExamples.Test
     // It example the FSharpExamples assembly that find all types implements IExample
     static member val CSharpExamples = findTestCases (typeof<Prajna.Examples.CSharp.MatchWord>)
+
+    // To be called before each test
+    [<SetUp>] 
+    member x.InitTest () =
+        sw.Start()
+        Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "##### Test %s starts (%s) #####" TestContext.CurrentContext.Test.FullName (StringTools.UtcNowToString())))
+
+    // To be called right after each test
+    [<TearDown>] 
+    member x.CleanUpTest () =
+        sw.Stop()
+        Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "##### Test %s ends (%s): %s (%i ms) #####" TestContext.CurrentContext.Test.FullName (StringTools.UtcNowToString()) (TestContext.CurrentContext.Result.Status.ToString()) sw.ElapsedMilliseconds))
+
 
     // A data driven tests that will run all the examples in Prajna.Examples.FSharp
     [<Test(Description = "Test for FSharp Examples")>]

--- a/tests/ServiceLib/KVStore.fs
+++ b/tests/ServiceLib/KVStore.fs
@@ -55,15 +55,20 @@ type KVStoreServiceTests () =
     let clusterSize = 1  
     let storeName = "TestKV"
     let serverInfo = ContractServersInfo( Cluster = cluster )
+
+    let sw = Diagnostics.Stopwatch()
+
     // To be called before each test
     [<SetUp>] 
     member x.InitTest () =
+        sw.Start()
         Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "##### Test %s starts (%s) #####" TestContext.CurrentContext.Test.FullName (StringTools.UtcNowToString())))
 
     // To be called right after each test
     [<TearDown>] 
     member x.CleanUpTest () =
-        Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "##### Test %s ends (%s): %s #####" TestContext.CurrentContext.Test.FullName (StringTools.UtcNowToString()) (TestContext.CurrentContext.Result.Status.ToString())))
+        sw.Stop()
+        Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "##### Test %s ends (%s): %s (%i ms) #####" TestContext.CurrentContext.Test.FullName (StringTools.UtcNowToString()) (TestContext.CurrentContext.Result.Status.ToString()) sw.ElapsedMilliseconds))
 
     [<Test(Description = "Start a service remotely")>]
     member x.KVStoreServiceStart() =


### PR DESCRIPTION
1. Kill hanging nunit-agent.exe if any when unit test completes
2. Measure test time
3. When there's only when drive, do not exclude it for data drive. Also handle mono differently.
