### PR TITLE
Build Script Update: Source Link Works.

### DIFF
--- a/src/CoreLib/cluster.fs
+++ b/src/CoreLib/cluster.fs
@@ -1129,6 +1129,7 @@ and
         Cluster.Start( null, cluster )
     /// Stop all connnections and disconnect all clusters. 
     static member Stop() = 
+        Logger.Log( LogLevel.ExtremeVerbose, ("Shutdown all clusters, no more jobs should be executed."))
         CleanUp.Current.CleanUpAll()
     interface IComparable<Cluster> with 
         member x.CompareTo y = 


### PR DESCRIPTION
Update build script to copy sourceLinked PDB to all other project, so that source link works for every project.

Make sure that CleanUp is not pulled into inline, which causes an exception in release build. 
