### PR TITLE
DSet.fold can use null. Build NuGet package even sourceLink fails. 

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -378,14 +378,17 @@ Target "SourceLink" (fun _ ->
     !! "src/**/*.??proj"
     |> Seq.iter (fun projFile -> 
         let proj = VsProj.LoadRelease projFile 
-        SourceLink.Index proj.CompilesNotLinked proj.OutputFilePdb __SOURCE_DIRECTORY__ baseUrl 
-        let pdbShortName = Path.GetFileName( proj.OutputFilePdb )
-        let bExist, entry = dic.TryGetValue( pdbShortName )
-        if bExist then 
-            for file1 in entry do 
-                if String.Compare( Path.GetFullPath(proj.OutputFilePdb), Path.GetFullPath(file1), true )<>0 then 
-                    trace ( sprintf "To copy file %s to %s " proj.OutputFilePdb file1 )
-                    File.Copy( proj.OutputFilePdb, file1, true )
+        try
+            SourceLink.Index proj.CompilesNotLinked proj.OutputFilePdb __SOURCE_DIRECTORY__ baseUrl 
+            let pdbShortName = Path.GetFileName( proj.OutputFilePdb )
+            let bExist, entry = dic.TryGetValue( pdbShortName )
+            if bExist then 
+                for file1 in entry do 
+                    if String.Compare( Path.GetFullPath(proj.OutputFilePdb), Path.GetFullPath(file1), true )<>0 then 
+                        // trace ( sprintf "To copy file %s to %s " proj.OutputFilePdb file1 )
+                        File.Copy( proj.OutputFilePdb, file1, true )
+        with 
+        | ex -> traceImportant (sprintf "Fail to sourceLink file '%s': %s" proj.OutputFilePdb ex.Message)
     )
     CopyBinariesFun("Releasex64")
 )

--- a/src/CoreLib/GV.fs
+++ b/src/CoreLib/GV.fs
@@ -1205,7 +1205,7 @@ type internal FoldFunction<'U, 'State >( func ) =
     inherit FoldFunction( 
         let wrapperFunc (stateobj:Object) (meta, elemObject:Object ) = 
             if Utils.IsNotNull elemObject then 
-               let state = stateobj :?> 'State
+               let state = if Utils.IsNull stateobj then Unchecked.defaultof<_> else stateobj :?> 'State
                let elemArray = elemObject :?> ('U)[]                              
                ( elemArray |> Array.fold func state ) :> Object
             else


### PR DESCRIPTION
Allow null to pass to DSet.fold. Allow build NuGet package when some of the files have not been committed to the main branch.
