### PR TITLE
Getting git owner using LibGit2Sharp

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -9,6 +9,7 @@ nuget FAKE
 nuget SourceLink.Fake
 nuget FSharp.Charting 0.90.9
 nuget Extended.Wpf.Toolkit 2.4
+nuget LibGit2Sharp
 
 github fsharp/FAKE modules/Octokit/Octokit.fsx
 

--- a/paket.lock
+++ b/paket.lock
@@ -1,8 +1,8 @@
 NUGET
   remote: https://nuget.org/api/v2
   specs:
-    Extended.Wpf.Toolkit (2.4)
-    FAKE (4.1.4)
+    Extended.Wpf.Toolkit (2.4.0)
+    FAKE (4.3.3)
     FSharp.Charting (0.90.9)
     FSharp.Compiler.Service (1.4.0.1)
     FSharp.Data (2.1.1)
@@ -12,6 +12,7 @@ NUGET
       FSharpVSPowerTools.Core (1.8.0)
     FSharpVSPowerTools.Core (1.8.0)
       FSharp.Compiler.Service (>= 0.0.87)
+    LibGit2Sharp (0.21.0.176)
     Microsoft.Bcl (1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
     Microsoft.Bcl.Build (1.0.21)
@@ -22,12 +23,12 @@ NUGET
     NUnit.Runners (2.6.4)
     Octokit (0.14.0)
       Microsoft.Net.Http
-    SourceLink.Fake (1.0.0)
+    SourceLink.Fake (1.1.0)
     Zlib.Portable (1.11.0) - framework: portable-net40+sl50+wp80+win80
 GITHUB
   remote: fsharp/FAKE
   specs:
-    modules/Octokit/Octokit.fsx (56f47d2c0b59f9835c7339bd9a92d3e983ff6f93)
+    modules/Octokit/Octokit.fsx (fd2e6b5c783b5c099273c26cc0ae893583a503a7)
       Octokit
 HTTP
   remote: https://download.sysinternals.com


### PR DESCRIPTION
Getting git owner using LibGit2Sharp which is more systematic/reliable to use than Fake.Git, and have full Git functionalities that can be useful in the future for scripting.
