### PR TITLE
Workaround the issue of slow shutdown of local cluster during unit test tear down phase

### DIFF
--- a/src/CoreLib/deploy.fs
+++ b/src/CoreLib/deploy.fs
@@ -408,6 +408,9 @@ type DeploymentSettings() =
     /// The time interval that the container will wait for a analytical job to complete
     static member val internal ContainerMaxWaitForJobToFinish = TimeSpan.FromSeconds(5.0) with get
 
+    /// The wait time for unload an appdomain that is hosting a daemon or container.
+    static member val internal AppDomainUnloadWaitTime = TimeSpan.FromSeconds(1.0) with get
+
 
 (*---------------------------------------------------------------------------
     05/31/2014, Jin Li

--- a/src/tools/tools/process.fs
+++ b/src/tools/tools/process.fs
@@ -808,7 +808,7 @@ type internal ThreadTracking private () as this =
             let elapseMs = curTime.Subtract( startTime ).TotalMilliseconds
             let waitMs = Math.Max( 0, millisecondTimeout - int elapseMs )
             let bTerminate = thread.Join( waitMs ) 
-            Logger.LogF( LogLevel.MildVerbose, ( fun _ -> sprintf "ThreadTracking, waiting for thread %s to join is %A" name bTerminate ))
+            Logger.LogF( LogLevel.MildVerbose, ( fun _ -> sprintf "ThreadTracking, waiting for thread (%d) %s to join is %A" thread.ManagedThreadId name bTerminate ))
         ThreadTracking.nCloseAllCalled := 0
     /// Standard form for all class that use CleanUp service
     override x.Finalize() =


### PR DESCRIPTION
Currently, in unit test, shutdown the local cluster takes 20+ seconds. This is due to the appdomain unload for daemon/container stucks for very long time until each reach the ThreadTracking's ThreadJoinTimeOut (10 seconds). Haven't figured out why the unload can take such long time. Temporarily workaround this issue by giving the unload a time buget of 1 second. So the UT shutdown can complete much quicker.

Note:
1. This behavior of cannot unload the appdomains that hosts deamons and containers for local cluster only happens in UT, and it does not repro when local cluster is used for the examples. It might be related to NUnit but we haven't been able to identify the root cause yet
2. Only UT uses appdomain to host daemon and container right now.
2. when reach the code to unload the daemon and container, the main logic in daemon and container has completed.
