### PR TITLE
For C#, add Linq API mappings in namespace Prajna.Api.CSharp.Linq

### DIFF
--- a/samples/examples/CSharpExamples/MatchWord.cs
+++ b/samples/examples/CSharpExamples/MatchWord.cs
@@ -28,6 +28,7 @@ namespace Prajna.Examples.CSharp
 
     using Prajna.Core;
     using Prajna.Api.CSharp;
+    using Prajna.Api.CSharp.Linq;
 
     using Prajna.Examples.Common;
 
@@ -54,8 +55,8 @@ namespace Prajna.Examples.CSharp
 
             var corpusLines = dset.LoadSource();
             var count1 =
-                corpusLines.Collect(SplitWords)
-                    .Filter(w => w == matchWord)
+                corpusLines.SelectMany(SplitWords)
+                    .Where(w => w == matchWord)
                     .Count();
             Console.WriteLine("Counted with DSet: The word {0} occurs {1} times", matchWord, count1);
 

--- a/samples/examples/CSharpExamples/PiEstimation.cs
+++ b/samples/examples/CSharpExamples/PiEstimation.cs
@@ -27,6 +27,7 @@ namespace Prajna.Examples.CSharp
 
     using Prajna.Core;
     using Prajna.Api.CSharp;
+    using Prajna.Api.CSharp.Linq;
 
     using Prajna.Examples.Common;
 
@@ -46,7 +47,7 @@ namespace Prajna.Examples.CSharp
             var value =
                 (new DSet<int> { Name = name, Cluster = cluster })
                 .SourceI(NumPartitions, i => Enumerable.Range(1, NumSamplesPerPartition).Select(j => i * NumSamplesPerPartition + j))
-                .Map(i =>
+                .Select(i =>
                          {
                              var rnd = new Random(i);
                              var x = rnd.NextDouble();
@@ -57,7 +58,7 @@ namespace Prajna.Examples.CSharp
                                  return 0.0;
                          }
                 )
-                .Reduce((a, b) => a + b);
+                .Aggregate((a, b) => a + b);
 
             var pi = (value * 4.0) / NumSamples;
 

--- a/samples/examples/CSharpExamples/WordCount.cs
+++ b/samples/examples/CSharpExamples/WordCount.cs
@@ -1,4 +1,4 @@
-//---------------------------------------------------------------------------
+﻿//---------------------------------------------------------------------------
 //    Copyright 2013 Microsoft
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,7 @@ namespace Prajna.Examples.CSharp
 
     using Prajna.Core;
     using Prajna.Api.CSharp;
+    using Prajna.Api.CSharp.Linq;
 
     using Prajna.Examples.Common;
 
@@ -51,7 +52,7 @@ namespace Prajna.Examples.CSharp
             var count1 =
                 (new DSet<string> { Name = name, Cluster = cluster })
                 .Distribute(corpus)
-                .Collect(SplitWords)
+                .SelectMany(SplitWords)
                 .Count();
 
             Console.WriteLine("Counted with DSet: there are {0} words", count1);

--- a/samples/examples/FSharpExamples/PiEstimation.fs
+++ b/samples/examples/FSharpExamples/PiEstimation.fs
@@ -50,7 +50,7 @@ type PiEstimation ()=
 
         printfn "Estimate Pi value: %f" pi
 
-        Math.Abs(pi - Math.PI) < 0.1
+        abs (pi - Math.PI) < 0.1
 
     interface IExample with
         member this.Description = 

--- a/src/CoreLib/CoreLib.fsproj
+++ b/src/CoreLib/CoreLib.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -96,6 +96,7 @@
     <Compile Include="DSetGenerics.fs" />
     <Compile Include="DKV.fs" />
     <Compile Include="DSetCSharp.fs" />
+    <Compile Include="DSetCSharpLinq.fs" />
     <Compile Include="service.fs" />
     <Compile Include="contractFSharp.fs" />
     <Compile Include="serviceFSharp.fs" />

--- a/src/CoreLib/DSetCSharp.fs
+++ b/src/CoreLib/DSetCSharp.fs
@@ -173,7 +173,7 @@ type DSet<'U> () =
     /// <param name="folder"> update the state given the input elements </param>
     /// <param name="aggrFunc"> aggregate the state from different partitions to a single state variable.</param>
     /// <param name="state"> initial state for each partition </param>
-    member private x.Fold (folder : Func<'State, 'U, 'State>, aggrFunc : Func<'State, 'State, 'State>, state : 'State) = 
+    member x.Fold (folder : Func<'State, 'U, 'State>, aggrFunc : Func<'State, 'State, 'State>, state : 'State) = 
         x.DSet.Fold(folder.ToFSharpFunc(), aggrFunc.ToFSharpFunc(), state)
 
     /// <summary>

--- a/src/CoreLib/DSetCSharpLinq.fs
+++ b/src/CoreLib/DSetCSharpLinq.fs
@@ -1,0 +1,99 @@
+﻿(*---------------------------------------------------------------------------
+    Copyright 2013 Microsoft
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.                                                      
+
+    File: 
+        DSetCSharpLinq.fs
+  
+    Description: 
+        CSharp Linq APIs for DSet<'U>
+
+    Author:																	
+        Jin Li, Principal Researcher
+        Microsoft Research, One Microsoft Way
+        Email: jinl at microsoft dot com
+    Date:
+        Sept. 2015
+    
+ ---------------------------------------------------------------------------*)
+namespace Prajna.Api.CSharp.Linq
+
+open System
+open System.Collections.Generic
+open System.Runtime.CompilerServices
+
+open Prajna.Api.CSharp
+
+[<Extension>]
+type DSetLinqExtensions =
+
+    /// Creates a new dataset whose elements are the results of applying the given function to each of the elements 
+    /// of the dataset. 
+    [<Extension>]
+    static member Select (dset : DSet<'U>, func : Func<'U, 'U1>) =
+        dset.Map(func)
+
+    /// Creates a new dataset whose elements are the results of applying the given function to each of the elements 
+    /// of the dataset. The first integer index passed to the function indicates the partition, and the second integer
+    /// passed to the function index (from 0) element within the partition
+    [<Extension>]
+    static member Select (dset : DSet<'U>, func : Func<'U, int, int64, 'U1>) =
+        dset.Mapi(fun partitionIndex indexInPartition u -> func.Invoke(u, partitionIndex, indexInPartition))
+
+    /// Applies the given function to each element of the dataset and concatenates all the results. 
+    [<Extension>]
+    static member SelectMany(dset : DSet<'U>, func : Func<'U, IEnumerable<'U1>>) =
+        dset.Collect(func)
+
+    /// Creates a new dataset containing only the elements of the dataset for which the given predicate returns true.
+    [<Extension>]
+    static member Where(dset : DSet<'U>, func : Func<'U, bool>) =
+        dset.Filter(func)
+
+    /// Fold the entire DSet with a fold function, an aggregation function, and an initial state. The initial state is deserialized (separately) for each partition. 
+    /// Within each partition, the elements are folded into the state variable using 'folder' function. Then 'aggrFunc' is used to aggregate the resulting
+    /// state variables from all partitions to a single state.
+    [<Extension>]
+    static member Aggregate(dset : DSet<'U>, state : 'State, folder : Func<'State, 'U, 'State>, aggrFunc : Func<'State, 'State, 'State>) =
+        dset.Fold(folder, aggrFunc, state)
+
+     /// Reduces the elements using the specified 'reducer' function
+    [<Extension>]
+    static member Aggregate(dset : DSet<'U>, reducer : Func<'U, 'U, 'U>) =
+        dset.Reduce(reducer)
+
+    /// Groups the elements of a dataset according to a specified key selector function.
+    [<Extension>]
+    static member GroupBy(dset : DSet<'U>, keySelector : Func<'U, 'K>) =
+        dset.Map(fun u -> (keySelector.Invoke(u), u)).GroupByKey()
+        
+    /// Groups the elements of a dataset according to a specified key selector function and projects the elements for each group by using a specified function.
+    [<Extension>]
+    static member GroupBy(dset : DSet<'U>, keySelector : Func<'U, 'K>, elementSelector : Func<'U, 'U1>) =
+        DSetLinqExtensions.GroupBy(dset, keySelector).Map(fun (_, grp) -> grp |> Seq.map(fun v -> elementSelector.Invoke(v)))
+        
+    /// Groups the elements of a dataset according to a specified key selector function and creates a result value from each group and its key.
+    [<Extension>]
+    static member GroupBy(dset : DSet<'U>, keySelector : Func<'U, 'K>, resultSelector : Func<'K, IEnumerable<'U>, 'U1>) =
+        DSetLinqExtensions.GroupBy(dset, keySelector).Map(fun (k, grp) -> resultSelector.Invoke(k, grp))
+
+    /// Groups the elements of a dataset according to a specified key selector function and creates a result value from each group and its key. The elements of each group are projected by using a specified function.
+    [<Extension>]
+    static member GroupBy(dset : DSet<'U>, keySelector : Func<'U, 'K>, elementSelector : Func<'U, 'U1>, resultSelector : Func<'K, IEnumerable<'U1>, 'U2>) =
+        DSetLinqExtensions.GroupBy(dset, keySelector).Map(fun (k, grp) -> k, grp |> Seq.map(fun v -> elementSelector.Invoke(v))).Map(fun (k, grp) -> resultSelector.Invoke(k, grp) )
+
+    /// Returns the dataset as an IEnumerable<'U>
+    [<Extension>]
+    static member AsEnumerable(dset : DSet<'U>) = 
+        dset.ToIEnumerable()


### PR DESCRIPTION
For C#, add Linq API mappings in namespace Prajna.Api.CSharp.Linq
- Only some of the common Linq APIs are mapped
- it's a conceptual map, not a strict 1-1 map
- Some mappings like "SelectMany -> Mapi", the parameters for SelectMany is different from Linq API, since we have the index of partition and elements in partition.
