### PR TITLE
Tolerate the exception on reading perf counter.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -401,7 +401,7 @@ let runTests (target:string) =
                                        |> NUnit (fun p ->
                                            { p with
                                                DisableShadowCopy = true
-                                               TimeOut = TimeSpan.FromMinutes 20.
+                                               TimeOut = TimeSpan.FromMinutes 10.
                                                OutputFile = sprintf "TestResults_%s_%d.xml" target i})
                     )
 #else
@@ -410,7 +410,7 @@ let runTests (target:string) =
                 DisableShadowCopy = true
                 ProcessModel = SeparateProcessModel
                 Domain = SingleDomainModel
-                TimeOut = TimeSpan.FromMinutes 20.
+                TimeOut = TimeSpan.FromMinutes 10.
                 OutputFile = sprintf "TestResults_%s.xml" target})    
 #endif
     finally

--- a/src/CoreLib/client.fs
+++ b/src/CoreLib/client.fs
@@ -125,18 +125,21 @@ type internal ClientLauncher() =
         if bUseAllDrive then 
             DeploymentSettings.UseAllDrivesForData()
   
-        // Trigger Tracefile creation, otherwise, MakeFileAccessible( logfname ) will fail. 
-        let ramCounter = new System.Diagnostics.PerformanceCounter("Memory", "Available MBytes")
-        // Find usable RAM space, leave 512MB, and use all. 
-        let usableRAM =( (int64 (ramCounter.NextValue())) - 512L ) <<< 20
-        if usableRAM > 0L then
-            let maxWorkingSet = 
-                if IntPtr.Size = 4 then 
-                    nativeint (Math.Min( usableRAM, 1300L<<<20 ))
-                else
-                    nativeint usableRAM
-            if maxWorkingSet > System.Diagnostics.Process.GetCurrentProcess().MinWorkingSet then
-                System.Diagnostics.Process.GetCurrentProcess().MaxWorkingSet <- maxWorkingSet
+        try
+            let ramCounter = new System.Diagnostics.PerformanceCounter("Memory", "Available MBytes")
+            // Find usable RAM space, leave 512MB, and use all. 
+            let usableRAM =( (int64 (ramCounter.NextValue())) - 512L ) <<< 20
+            if usableRAM > 0L then
+                let maxWorkingSet = 
+                    if IntPtr.Size = 4 then 
+                        nativeint (Math.Min( usableRAM, 1300L<<<20 ))
+                    else
+                        nativeint usableRAM
+                if maxWorkingSet > System.Diagnostics.Process.GetCurrentProcess().MinWorkingSet then
+                    System.Diagnostics.Process.GetCurrentProcess().MaxWorkingSet <- maxWorkingSet
+        with
+        | e -> // Exception here should not cause the program to fail, it's safe to continue 
+               Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "ClientLauncher.Main: exception on reading perf counter and set MaxWorkingSet: %A" e))
 
         if nTotalJob > 0 then 
             DeploymentSettings.TotalJobLimit <- nTotalJob


### PR DESCRIPTION
- From the log of one failed test run at AppVeyor, it turns out it fails due to an InvalidOperationException
  thrown from reading perf counter. It rarely happens and the underlying reason is unknown. Regardless, this exception
  should not cause the client to fail to start. It's not for any critial task. It should be logged and then swallow
  
  Change the UT test time out to 10 minutes
