### PR TITLE
Supporting memory-copy-based serialization of matrices

### DIFF
--- a/src/CoreLib/task.fs
+++ b/src/CoreLib/task.fs
@@ -1459,7 +1459,9 @@ and [<AllowNullLiteral; Serializable>]
                                         null
                                     else 
                                         // Start pos will not be the end of stream, garanteed by state not null 
-                                        new MemStream( buf, pos, length, false, true )
+                                        let msNew = new MemStream( buf, 0, pos + length, false, true )
+                                        msNew.Seek( int64 pos, SeekOrigin.Begin ) |> ignore 
+                                        msNew
                                 let stateFunc() = 
                                     if bCommonStatePerNode || Utils.IsNull state then 
                                         state

--- a/tests/tools/tools/serialize.fs
+++ b/tests/tools/tools/serialize.fs
@@ -28,9 +28,8 @@ module SerializationTests =
     [<Test>]
     let testPrimitiveArray() = testObject [|1..10|]
         
-//  Higher rank arrays not supported for now
-//    [<Test>]
-//    let testHigherRankArray() = testObject (Array2D.init 3 3 (fun i j -> 3 * i + j))
+    [<Test>]
+    let testHigherRankArray() = testObject (Array2D.init 3 3 (fun i j -> 3 * i + j))
         
     [<Test>]
     let testPrimitiveList() = testObject [1..10]
@@ -43,6 +42,7 @@ module SerializationTests =
             val Real: float
             val Imaginary: float
             new (r: float, i: float) = {Real = r; Imaginary = i; }
+            override this.ToString() = sprintf "(%f, %f)" this.Real this.Imaginary
         end
 
     [<Test>]
@@ -51,6 +51,12 @@ module SerializationTests =
     [<Test>]
     let testStructArray() = testObject [|Complex(1.0, 2.0); Complex(3.0, 4.0)|]
 
+    [<Test>]
+    let testHigherRankStructArray() = testObject <| Array2D.init 2 2 (fun i j -> Complex(float i, float j))
+        
+    [<Test>]
+    let testHigherRankObjectArray() = testObject <| Array2D.init 2 2 (fun i j -> sprintf "%A" (Complex(float i, float j)))
+        
     type PersonStruct =
         struct
             val Name: string


### PR DESCRIPTION
This adds support for generic, memory-copy-based serialization of matrices and higher rank arrays. Other than the update to zero-object replication by Jin on tasks.fs, it's all contained to generic serialization code.
