### PR TITLE
Deployment Scripts for domain cluster

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,5 +8,5 @@ version: 0.0.1.{build}
 
 # after build failure or success
 on_finish:
-  - ps: Add-Type -AssemblyName System.IO.Compression.FileSystem; $dest = [System.IO.Path]::Combine((Resolve-Path temp), "Log.Zip") ; [System.IO.Compression.ZipFile]::CreateFromDirectory("C:\OneNet\Log", $dest) ; Push-AppveyorArtifact $dest -FileName Log.Zip -DeploymentName to-publish
+  - ps: Add-Type -AssemblyName System.IO.Compression.FileSystem; $dest = [System.IO.Path]::Combine((Resolve-Path temp), "Log.Zip") ; [System.IO.Compression.ZipFile]::CreateFromDirectory("C:\Prajna\Log", $dest) ; Push-AppveyorArtifact $dest -FileName Log.Zip -DeploymentName to-publish
 

--- a/nuget/Prajna.paket.template
+++ b/nuget/Prajna.paket.template
@@ -31,6 +31,8 @@ files
     !../src/Client/Client/bin/Releasex64/*.srcsrv
     ../src/Client/ClientExt/bin/Releasex64/PrajnaClientExt* ==> tools/Client
     !../src/Client/ClientExt/bin/Releasex64/*.srcsrv
+    ../scripts ==> tools/Scripts
+    ../src/Toolkit/ClusterStatus/bin/Releasex64 ==> tools/ClusterStatus
 references
     Prajna.dll
     Prajna.Tools.dll

--- a/scripts/README.txt
+++ b/scripts/README.txt
@@ -1,0 +1,125 @@
+Deployment of Prajna
+
+This document describes the basics on Prajna deployment.
+=========================================================
+1. Introduction 
+=========================================================
+
+---------------------------------------------------------
+1.1 Machine provision, deployment, and launch the client
+---------------------------------------------------------
+
+  The essential of Prajna deployment to a cluster (or just a set of machines) is to copy and launch the Prajna client
+  to each properly provisioned machine. 
+
+  A Prajna client is going to use 
+  * a port for accepting job requests
+  * a range of ports to communicate between peers
+
+  So the most basic requirement for a machine is to open these ports. Thereafter, the Prajna client can be launched using
+  these ports. Of course, these machines need to be accessible from the machine where user runs Prajna applications.
+
+  The client is called "PrajnaClient.exe"
+  * For user of the Nuget package, when the Prajna package is installed, the client and its dependencies are located in subfolder tools\Client
+  * For user of the GitHub source code, after the source tree is built, the client and its dependencies are located in subfolder bin\ReleaseX64\Client or bin\DebugX64\Client
+
+  To launch the client, use the following arguments
+
+      -port 1005 -jobport 1250-1300
+
+  An extra argument can be provided it request authentication is desired.
+
+      -pwd somepasswd  
+
+Depending on the environment and user preference, the way to provision, deploy, and launch the client can vary. 
+
+---------------------------------------------------------
+1.2 Cluster List File
+---------------------------------------------------------
+
+  Once the client is deployed to a set of machines. User needs to construct a cluster list file that the Prajna application will use.
+
+  It is a plain-text file with an ".lst" extension. An example looks like
+  
+      MyCluster,1005,somepasswd
+      Machine0
+      Machine1
+      Machine2
+  
+  The first line specifies "ClusterName,Port,Password". 
+  ClusterName is a unique identifier of the cluster that the runtime will use. 
+  Port is what specified by "-job" argument during client launch. If the client is launched with a "-pwd" argument, please also specify the password.
+
+---------------------------------------------------------
+1.3 Verify the deployment
+---------------------------------------------------------
+
+  Use a tool called ClusterStatus.exe
+  * For user of the Nuget package, it is located in subfolder tools\ClusterStatus
+  * For user of the GitHub source code, after the source tree is built, it is located in subfolder bin\ReleaseX64\ClusterStatus or bin\DebugX64\ClusterStatus
+
+  If the tool can show the disk usages etc on the target machines, it means the deployment is successful.
+
+---------------------------------------------------------
+1.4 Use the Cluster
+---------------------------------------------------------
+
+  Prajna applications will construct the cluster object by (in C#) supplying the path to this list file:
+  
+      var cluster = new Cluster(pathToLstFile);
+      
+=========================================================
+2. Deployment to Windows Cluster
+=========================================================
+
+This section describes how to use provided Powershell scripts to deploy and launch the Prajna client on a cluster of windows domain-joined machines.
+
+---------------------------------------------------------
+2.1 Scripts
+---------------------------------------------------------
+
+  For user of Nuget package, the scripts are located in tools\Scripts\WindowsDomainCLuster
+  For user of GitHub source, the scripts are located at src\Scripts\WindowsDomainCluster
+
+---------------------------------------------------------
+2.1 Prerequisites
+---------------------------------------------------------
+
+  For all target machines
+  a) User needs to have a credential with admin privilege 
+  b) PowerShell remote execution is enabled
+  c) The ports that will be used by the client are opened
+
+---------------------------------------------------------
+2.2 Deployment
+---------------------------------------------------------
+
+  In PowerShell, cd to the folder where the scripts locate, and invoke "Deploy-Clients.ps1"
+  
+    PS>  .\Deploy-Clients.ps1 -ComputerNames @("Machine1", "Machine2", "Machine3") -SourceLocation ..\..\Client -ClientLocation C:\Deployment\PrajnaClient -Port 1005 -JobPortRange 1250-1299
+  
+    -ComputerNames specifies an array of target machines
+    -SourceLocation specifies the absolute or relative path to the folder that contains the client
+    -ClientLocation specifies the path to put the client on target machines
+    -Port specifies the port for the client to accept job requests
+    -JobPortRange specifies the range of ports to be used by the client
+
+  To enable authentication, add an extra "-Password" parameter to pass in a string of desired password
+
+---------------------------------------------------------
+2.4 Other scripts
+---------------------------------------------------------
+
+  * Start-Clients.ps1 : start clients on machines by specify the location of the clients on the machines, for example
+  
+     PS> .\Start-Clients.ps1 -ComputerNames @("Machine1", "Machine2", "Machine3") -ClientLocation C:\Deployment\PrajnaClient -Port 1005 -JobPortRange 1250-1299 -ShutdownRunningClients $true
+     
+  * Stop-Clients.ps1: stop clients on machines by specify the location of the clients on the machines
+     
+     pS> .\Stop-Clients.ps1 -ComputerNames @("Machine1", "Machine2", "Machine3") -ClientLocation C:\Deployment\PrajnaClient
+  
+  * Start-Client.ps1 : start the client on a single machine
+  * Stop-Client.ps1: stop the client on a single machine
+  
+
+

--- a/scripts/WindowsDomainCluster/Deploy-Clients.ps1
+++ b/scripts/WindowsDomainCluster/Deploy-Clients.ps1
@@ -1,0 +1,78 @@
+##############################################################################
+## Deploy and start Prajna clients on Windows domain joined machines
+##############################################################################
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string] $SourceLocation,
+    [Parameter(Mandatory=$true)]
+    [string[]] $ComputerNames,
+    [Parameter(Mandatory=$true)] 
+    [string] $ClientLocation,
+    [Parameter(Mandatory=$true)] 
+    [int] $Port,
+    [Parameter(Mandatory=$true)] 
+    [ValidatePattern("[0-9]+-[0-9]+")] # Example: 11000-12000
+    [string] $JobPortRange,
+    [int] $MemorySize = 1024, # in MB
+    [int] $LogLevel = 4,
+    [string] $LogDir,
+    [string] $Password,
+    [PSCredential] $Cred
+)
+
+$ClientName = "PrajnaClient.exe"
+
+if ($ComputerNames.Count -eq 0)
+{
+    Write-Error "No computer specified by -ComputerNames"
+    Exit
+}
+
+if (!(Test-Path $SourceLocation))
+{
+    Write-Error “Invalid location '$SourceLocation' specified by -SourceLocation."
+    exit
+}
+
+if (!(Test-Path (Join-Path $SourceLocation $ClientName)))
+{
+    Write-Error “'$SourceLocation' (specified by -SourceLocation) does not contain the Prajna client."
+    exit
+}
+
+# stop the clients if any to allow the copy
+.\Stop-Clients.ps1 -ComputerNames $ComputerNames -ClientLocation $ClientLocation
+
+
+# copy files
+$ClientLocationDrive = (Split-Path -Path $ClientLocation -Qualifier).Replace(':', '$')
+$ClientLocationFolder = Split-Path -Path $ClientLocation -NoQualifier
+
+Foreach ($ComputerName in $ComputerNames)
+{
+    $Root = "\\$ComputerName\$ClientLocationDrive"
+    # Write-Output "Root: $Root"
+    if ($Cred)
+    {
+        New-PSDrive -Name $ComputerName -Root $Root -PSProvider FileSystem -Credential $Cred | Out-Null
+    }
+    else
+    {
+        New-PSDrive -Name $ComputerName -Root $Root -PSProvider FileSystem | Out-Null
+    }
+
+    $Dest = "$ComputerName" +":\" + $ClientLocationFolder
+
+    if (!(Test-Path $Dest))
+    {
+        New-Item -ItemType directory -Path $Dest -Force | Out-Null
+    }
+
+    Copy-Item -Path $SourceLocation\* -Destination $Dest -Force -Recurse 
+    Remove-PSDrive -Name $ComputerName
+    Write-Output "The client is copied over to machine $ComputerName"
+}
+
+# start the clients
+.\Start-Clients.ps1 -ComputerNames $ComputerNames -ClientLocation $ClientLocation -Port $Port -JobPortRange $JobPortRange -MemorySize $MemorySize -LogLevel $LogLevel -LogDir $LogDir -Password $Password -Cred $Cred -ShutdownRunningClients $true

--- a/scripts/WindowsDomainCluster/Start-Client.ps1
+++ b/scripts/WindowsDomainCluster/Start-Client.ps1
@@ -1,0 +1,114 @@
+##############################################################################
+## Start a Prajna client on a Windows domain machine
+##############################################################################
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string] $ComputerName,
+    [Parameter(Mandatory=$true)] 
+    [string] $ClientLocation,
+    [Parameter(Mandatory=$true)] 
+    [int] $Port,
+    [Parameter(Mandatory=$true)] 
+    [ValidatePattern("[0-9]+-[0-9]+")] # Example: 11000-12000
+    [string] $JobPortRange,
+    [int] $MemorySize = 1024, # in MB
+    [int] $LogLevel = 4,
+    [string] $LogDir,
+    [string] $Password,
+    [bool] $ShutdownRunningClients = $false,
+    [PSCredential] $Cred
+)
+
+$JobRangeArray = $JobPortRange -split "-"
+if ([convert]::ToInt32($JobRangeArray[0]) -gt [convert]::ToInt32($JobRangeArray[1]))
+{
+    Write-Error "Invalid job port range: $JobPortRange."
+    Exit
+}
+
+
+$Sb = {
+    Param([string]$ClientLocation,
+          [int] $Port,
+          [string] $JobPortRange,
+          [int] $MemorySize,
+          [int] $LogLevel,
+          [string] $LogDir,
+          [string] $Password,
+          [bool] $ShutdownRunningClients) 
+
+    $ClientName = "PrajnaClient.exe"    
+
+    if (!(Test-Path $ClientLocation))
+    {
+        Write-Error "$ClientLocation (specified by -ClientLocation) does not exist."
+        return $false
+    }
+
+    $ClientPath = Join-Path $ClientLocation $ClientName
+    if (!(Test-Path $ClientPath))
+    {
+        Write-Error "Cannot find the client at location specified by -ClientLocation."
+        return $false
+    }
+
+    $ClientNameWithoutExtension = ([System.IO.Path]::GetFileNameWithoutExtension($ClientName))
+   
+    $Procs = Get-Process -Name $ClientNameWithoutExtension -ErrorAction SilentlyContinue
+    if ($Procs)
+    {
+        if ($ShutdownRunningClients)
+        {
+            $Procs | Where-Object { $_.Path -eq $ClientPath } | Stop-Process -Force -Verbose
+        }
+        else
+        {
+            $P = $Proc.Path
+            Write-Error "There are one or more clients are still running ."
+            return $false
+        }
+    }
+
+    
+    $Cmd = "$ClientPath -mem $MemorySize -verbose $LogLevel -port $Port -jobport $JobPortRange"
+    if ($LogDir)
+    {
+        $Cmd = $Cmd + " -dirlog $LogDir"
+    }
+    if ($Password)
+    {
+        $Cmd = $Cmd + " -pwd $Password"
+    }
+
+    $result = Invoke-WmiMethod -path win32_process -name create -argumentlist @($Cmd, $ClientLocation)
+
+    $Procs = Get-Process -Name $ClientNameWithoutExtension -ErrorAction SilentlyContinue
+    if ($Procs)
+    {
+        $Proc = $Procs | Where-Object { $_.Path -eq $ClientPath }
+        if ($Proc -and !$Proc.HasExited)
+        {
+            return $true;
+        }
+        else
+        {
+            return $false;
+        }
+    }
+    else
+    {
+        return $false;
+    }
+}
+
+if ($Cred)
+{
+    $State = Invoke-Command -ComputerName $ComputerName -EnableNetworkAccess -Authentication CredSSP -Credential $Cred -ScriptBlock $Sb -ArgumentList @($ClientLocation, $Port, $JobPortRange, $MemorySize, $LogLevel, $LogDir, $Password, $ShutdownRunningClients)
+    Write-Output "Machine $ComputerName : Start-Client : $State"
+}
+else
+{
+    $State = Invoke-Command -ComputerName $ComputerName -EnableNetworkAccess -ScriptBlock $Sb -ArgumentList @($ClientLocation, $Port, $JobPortRange, $MemorySize, $LogLevel, $LogDir, $Password, $ShutdownRunningClients)
+    Write-Output "Machine $ComputerName : Start-Client : $State"
+}

--- a/scripts/WindowsDomainCluster/Start-Clients.ps1
+++ b/scripts/WindowsDomainCluster/Start-Clients.ps1
@@ -1,0 +1,40 @@
+##############################################################################
+## Start Prajna clients on Windows domain joined machines
+##############################################################################
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string[]] $ComputerNames,
+    [Parameter(Mandatory=$true)] 
+    [string] $ClientLocation,
+    [Parameter(Mandatory=$true)] 
+    [int] $Port,
+    [Parameter(Mandatory=$true)] 
+    [ValidatePattern("[0-9]+-[0-9]+")] # Example: 11000-12000
+    [string] $JobPortRange,
+    [int] $MemorySize = 1024, # in MB
+    [int] $LogLevel = 4,
+    [string] $LogDir,
+    [string] $Password,
+    [bool] $ShutdownRunningClients = $false,
+    [PSCredential] $Cred
+)
+
+if ($ComputerNames.Count -eq 0)
+{
+    Write-Error "No computer specified by -ComputerNames"
+    Exit
+}
+
+$JobRangeArray = $JobPortRange -split "-"
+if ([convert]::ToInt32($JobRangeArray[0]) -gt [convert]::ToInt32($JobRangeArray[1]))
+{
+    Write-Error "Invalid job port range: $JobPortRange."
+    Exit
+}
+
+# start the clients in sequence 
+Foreach ($ComputerName in $ComputerNames)
+{
+    .\Start-Client.ps1 -ComputerName $ComputerName -ClientLocation $ClientLocation -Port $Port -JobPortRange $JobPortRange -MemorySize $MemorySize -LogLevel $LogLevel -LogDir $LogDir -Password $Password -Cred $Cred -ShutdownRunningClients $ShutdownRunningClients
+}

--- a/scripts/WindowsDomainCluster/Stop-Client.ps1
+++ b/scripts/WindowsDomainCluster/Stop-Client.ps1
@@ -1,0 +1,44 @@
+##############################################################################
+## Stop a Prajna client on a Windows domain joined machine
+##############################################################################
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string] $ComputerName,
+    [Parameter(Mandatory=$true)] 
+    [string] $ClientLocation,
+    [PSCredential] $Cred
+)
+
+$Sb = {
+    param(
+        [string] $ClientLocation
+    )
+
+    $ClientName = "PrajnaClient.exe"
+
+
+    if (!(Test-Path $ClientLocation))
+    {
+        # If it does not exist, there's nothing to stop
+        return $true
+    }
+
+    $ClientNameWithoutExtension = ([System.IO.Path]::GetFileNameWithoutExtension($ClientName))
+    $ClientPath = Join-Path $ClientLocation $ClientName
+    
+    $Procs = Get-Process -Name $ClientNameWithoutExtension -ErrorAction SilentlyContinue
+    $Procs | Where-Object { $_.Path -eq $ClientPath } | Stop-Process -Force
+    return $true
+}
+
+if ($Cred)
+{
+    $State = Invoke-Command -ComputerName $ComputerName -EnableNetworkAccess -Authentication CredSSP -Credential $Cred -ScriptBlock $Sb -ArgumentList @($ClientLocation)
+    Write-Output "Machine $ComputerName : Stop-Client : $State" 
+}
+else
+{
+    $State = Invoke-Command -ComputerName $ComputerName -EnableNetworkAccess -ScriptBlock $Sb -ArgumentList @($ClientLocation)
+    Write-Output "Machine $ComputerName : Stop-Client : $State"
+}

--- a/scripts/WindowsDomainCluster/Stop-Clients.ps1
+++ b/scripts/WindowsDomainCluster/Stop-Clients.ps1
@@ -1,0 +1,23 @@
+##############################################################################
+## Stop Prajna clients on Windows domain joined machines
+##############################################################################
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string[]] $ComputerNames,
+    [Parameter(Mandatory=$true)] 
+    [string] $ClientLocation,
+    [PSCredential] $Cred
+)
+
+if ($ComputerNames.Count -eq 0)
+{
+    Write-Error "No computer specified by -ComputerNames"
+    Exit
+}
+
+# start the clients in sequence 
+Foreach ($ComputerName in $ComputerNames)
+{
+    .\Stop-Client.ps1 -ComputerName $ComputerName -ClientLocation $ClientLocation -Cred $Cred
+}

--- a/src/Client/Client/Client.fsproj
+++ b/src/Client/Client/Client.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -43,11 +43,6 @@
     <ProjectReference Include="..\..\Tools\Tools\Tools.fsproj">
       <Name>Tools</Name>
       <Project>{159bb552-8346-4313-8e10-43b88beca63b}</Project>
-      <Private>True</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\ClientExt\ClientExt.fsproj">
-      <Name>ClientExt</Name>
-      <Project>{ea8c1f76-66da-4aad-ade8-3ab016672ff5}</Project>
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>

--- a/src/CoreLib/DSeq.fs
+++ b/src/CoreLib/DSeq.fs
@@ -909,10 +909,6 @@ and [<AllowNullLiteral>]
 
                         x.MonitorSendPeerStatus peeri peerQueue bCansend
                         if ( bCansend || (peerQueue.CanSend && bForceSend) ) then 
-//                            Logger.LogF(LogLevel.MildVerbose, (fun _ -> 
-//                                let qq = peerQueue.CompSend.Q :?> OneNet.Tools.Queue.FixedSizeQ<NetworkCommand>
-//                                sprintf "QSize current: %d max: %d" qq.CurrentSize qq.MaxSize
-//                            ))
                             peerQueue.ToSend( cmd, ms )
                             if (Utils.IsNotNull ms) then
                                 ms.DecRef()

--- a/src/CoreLib/clientparse.fs
+++ b/src/CoreLib/clientparse.fs
@@ -300,7 +300,7 @@ type internal Listener =
                             let obj = ClusterInfo.Unpack( ms )
                             match obj with
                             | Some ( cluster ) ->
-                                let fname = cluster.Persist()
+                                cluster.Persist()
                                 if Utils.IsNotNull queuePeer.SetDSetMSG then 
                                     queuePeer.SetDSet( )
                                 else    

--- a/src/CoreLib/deploy.fs
+++ b/src/CoreLib/deploy.fs
@@ -139,7 +139,7 @@ type DeploymentSettings() =
             drives |> Seq.find( fun drive -> not (DeploymentSettings.ExcludedDrives.ContainsKey( drive )) )
     static member val internal GetFirstDataDrive = DeploymentSettings.GetFirstDataDriveImpl with get, set
     /// Directory at remote node that holds Prajna operating state. 
-    static member val LocalFolder = Path.Combine(DeploymentSettings.RootFolder, "OneNet") with get
+    static member val LocalFolder = Path.Combine(DeploymentSettings.RootFolder, "Prajna") with get
     /// Directory at remote node that holds strong hashed file of the remote execution roster. 
     static member val HashFolder = @"HashFolder" with get
     static member val internal LogFolder = Path.Combine(DeploymentSettings.LocalFolder, "Log") with get, set
@@ -159,7 +159,7 @@ type DeploymentSettings() =
     static member val internal MasterPort = 1080 with get, set
     static member val internal ControlPort = 1081 with get, set
     /// Directory at remote node that holds Prajna data files
-    static member val DataFolder = @"OneNetData" with get
+    static member val DataFolder = @"PrajnaData" with get
     static member val internal ClusterFolder = "Cluster" with get
     static member val internal AssemblyFolder = Path.Combine(DeploymentSettings.LocalFolder, "Assembly") with get
     static member val internal JobFolder = "Job" with get

--- a/src/CoreLib/job.fs
+++ b/src/CoreLib/job.fs
@@ -1713,7 +1713,7 @@ and
                 let clOpt = ClusterInfo.Unpack( stream )
                 match clOpt with 
                 | Some( clusterinfo ) ->
-                    clusterinfo.Persist() |> ignore
+                    clusterinfo.Persist()
                     let cluster = ClusterFactory.FindCluster( clusterinfo.Name, clusterinfo.Version.Ticks )
                     blob.Object <- cluster
                     x.Clusters.[blob.Index] <- cluster

--- a/src/CoreLib/network.fs
+++ b/src/CoreLib/network.fs
@@ -1340,6 +1340,12 @@ and [<AllowNullLiteral>] NetworkConnections() as x =
         if Utils.IsNotNull dirpath then
             FileTools.DirectoryInfoCreateIfNotExists (dirpath) |> ignore
 
+    /// Initialize authentication using a shared secret password 
+    member x.InitializeAuthentication (pwd : string) : unit =
+        let keyFile =  Path.Combine( [| DeploymentSettings.LocalFolder; "Keys";  Guid.NewGuid().ToString("D") |] )
+        let keyFilePwd = Guid.NewGuid().ToString("D")
+        x.InitializeAuthentication(pwd, keyFile, keyFilePwd)
+
     /// Initialize authentication / security information from keyfile (encrypted with keyfilePwd)
     /// while also allowing for shared secret (password) to be used for authentication.
     /// <param name="pwd">A shared secret password which can be used for authentication</param>
@@ -1377,12 +1383,14 @@ and [<AllowNullLiteral>] NetworkConnections() as x =
             ms.WriteBytesWLen(exchangePrivateKey)
             File.WriteAllBytes(mykeyfile, ms.GetValidBuffer())
             ms.DecRef()
+            Logger.LogF (LogLevel.MildVerbose, fun _ -> sprintf "InitializeAuthentication: write to key file: %s" mykeyfile)
         else
             let ms = new MemStream(File.ReadAllBytes(mykeyfile))
             x.MyGuid <- new Guid(ms.ReadBytes(sizeof<Guid>))
             x.MyAuthRSA <- Crypt.RSAFromPrivateKey(ms.ReadBytesWLen(), x.KeyFilePassword)
             x.MyExchangeRSA <- Crypt.RSAFromPrivateKey(ms.ReadBytesWLen(), x.KeyFilePassword)
             ms.DecRef()
+            Logger.LogF (LogLevel.MildVerbose, fun _ -> sprintf "InitializeAuthentication: read from key file: %s" mykeyfile)
         // add self to allowed list
         x.AllowedConnections.[x.MyGuid] <- (Crypt.RSAToPublicKey(x.MyAuthRSA), Crypt.RSAToPublicKey(x.MyExchangeRSA))
 

--- a/src/CoreLib/task.fs
+++ b/src/CoreLib/task.fs
@@ -3608,7 +3608,13 @@ type internal ContainerLauncher() =
         Logger.Log( LogLevel.Info, ( sprintf "%s executing in new Executable Environment ...................... %s, %d MB " 
                                                    (Process.GetCurrentProcess().MainModule.FileName) DeploymentSettings.PlatformFlag (DeploymentSettings.MaxMemoryLimitInMB) ))
         Logger.LogF( LogLevel.MildVerbose, ( fun _ -> sprintf "Current working directory <-- %s " (Directory.GetCurrentDirectory()) ))
-        Logger.Log( LogLevel.Info, ( sprintf "Verbose level = %A, parameters %A " (Logger.DefaultLogLevel) orgargv ))
+
+        let argsToLog = Array.copy orgargv
+        for i in 0..argsToLog.Length-1 do
+            if String.Compare(argsToLog.[i], "-rsapwd", StringComparison.InvariantCultureIgnoreCase) = 0 then
+                argsToLog.[i + 1] <- "****"
+
+        Logger.Log( LogLevel.Info, ( sprintf "Verbose level = %A, parameters %A " (Logger.DefaultLogLevel) argsToLog ))
     //    MakeFileAccessible( logfname )
     //        let task = Task( SignatureName=name, SignatureVersion=ver )
         Task.StartTaskAsSeperateApp( name, ver, ip, port, jobip, jobport, (requireAuth, guid, rsaKey, rsaKeyPwd), clientId |> Some, clientModuleName |> Some, clientStartTimeTicks |> Some)

--- a/src/Toolkit/ClusterInfo/Program.fs
+++ b/src/Toolkit/ClusterInfo/Program.fs
@@ -28,7 +28,7 @@ let main argv =
     if (dumpClusterFile = true) then
         // dump inputcluster as text to screen
         for i=0 to inputClusterFiles.Length-1 do
-            let info = ClusterInfo.Read(inputClusterFiles.[i])
+            let info, _ = ClusterInfo.Read(inputClusterFiles.[i])
             match info with
                 | None -> printfn "File %A not found" inputClusterFiles.[i]
                 | Some(x) ->
@@ -82,12 +82,13 @@ let main argv =
         clusterInfo.ListOfClients <-
             inputClusterFilesI
             |> Seq.choose (fun (index, inputClusterFile) -> 
-                            match ClusterInfo.Read inputClusterFile with
+                            let clusterInfo, _ = ClusterInfo.Read inputClusterFile
+                            match clusterInfo with
                             | None -> printfn "File %A not found and ignored" inputClusterFile; None
-                            | info -> 
+                            | Some info -> 
                                 let start = if (index < inputStartNode.Length) then inputStartNode.[index] else 0
-                                let stop = if (index < inputEndNode.Length) then inputEndNode.[index] else info.Value.ListOfClients.Length-1
-                                Some(Array.sub info.Value.ListOfClients start (stop-start+1)))
+                                let stop = if (index < inputEndNode.Length) then inputEndNode.[index] else info.ListOfClients.Length-1
+                                Some(Array.sub info.ListOfClients start (stop-start+1)))
             |> Seq.concat
             |> Seq.toArray
         clusterInfo.Save(outputClusterFile)

--- a/src/tools/tools/Tools.fsproj
+++ b/src/tools/tools/Tools.fsproj
@@ -55,8 +55,6 @@
     <Compile Include="basenetwork.fs" />
     <Compile Include="genericnetwork.fs" />
     <Compile Include="crypt.fs" />
-    <None Include="Scripts\load-references.fsx" />
-    <None Include="Scripts\load-project.fsx" />
     <Compile Include="configuration.fs" />
   </ItemGroup>
   <PropertyGroup>


### PR DESCRIPTION
1. Deployment scripts for windows domain clusters
2. Support plain text list file - lst (so user does not have to use inf file)
3. Support password with the lst file
4. New algorithm on system saved cluster metadata
5. Fix a few issues/bugs

There're still a few TODO's
- Add a readme file with the scripts
- Include the scripts to the nuget package
- When the cluster requires passwd but user does not provide it, the exception message is not friendly. 
