### PR TITLE
Nuget spec: add System.Runtime.Serialization as frameworkAssemblies

### DIFF
--- a/nuget/Prajna.paket.template
+++ b/nuget/Prajna.paket.template
@@ -43,5 +43,6 @@ frameworkAssemblies
     System.Management
     System.Xml
     System.Xml.Linq
+    System.Runtime.Serialization
 dependencies
     FSharp.Core >= 3.1.2


### PR DESCRIPTION
A recent change makes Prajna.Tools depends on System.Runtime.Serialization
