### PR TITLE
Use "logdir" and "jobports" for client launch

### DIFF
--- a/Prajna.sln
+++ b/Prajna.sln
@@ -132,6 +132,20 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Gateway", "src\ServiceLib\G
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "ServiceEndpoint", "src\ServiceLib\ServiceEndpoint\ServiceEndpoint.fsproj", "{45959765-A1FA-4277-BC68-024CAD648546}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{012ABB28-19FD-4935-AB0B-9E34D8B93D92}"
+	ProjectSection(SolutionItems) = preProject
+		scripts\README.txt = scripts\README.txt
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WindowsDomainCluster", "WindowsDomainCluster", "{24176C7F-6562-4D88-80C9-56A5DD4C431D}"
+	ProjectSection(SolutionItems) = preProject
+		scripts\WindowsDomainCluster\Deploy-Clients.ps1 = scripts\WindowsDomainCluster\Deploy-Clients.ps1
+		scripts\WindowsDomainCluster\Start-Client.ps1 = scripts\WindowsDomainCluster\Start-Client.ps1
+		scripts\WindowsDomainCluster\Start-Clients.ps1 = scripts\WindowsDomainCluster\Start-Clients.ps1
+		scripts\WindowsDomainCluster\Stop-Client.ps1 = scripts\WindowsDomainCluster\Stop-Client.ps1
+		scripts\WindowsDomainCluster\Stop-Clients.ps1 = scripts\WindowsDomainCluster\Stop-Clients.ps1
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -590,5 +604,6 @@ Global
 		{A68BD032-F86B-49B6-B7ED-7300DB353705} = {B018B59D-85F0-419B-88B2-680E4126D5FD}
 		{C588134A-466C-4453-89AB-7DD7CEC58F06} = {B6B1E5E2-9BE5-4542-92C5-E85DE984C7D6}
 		{45959765-A1FA-4277-BC68-024CAD648546} = {B6B1E5E2-9BE5-4542-92C5-E85DE984C7D6}
+		{24176C7F-6562-4D88-80C9-56A5DD4C431D} = {012ABB28-19FD-4935-AB0B-9E34D8B93D92}
 	EndGlobalSection
 EndGlobal

--- a/scripts/README.txt
+++ b/scripts/README.txt
@@ -25,7 +25,7 @@ This document describes the basics on Prajna deployment.
 
   To launch the client, use the following arguments
 
-      -port 1005 -jobport 1250-1300
+      -port 1005 -jobports 1250-1300
 
   An extra argument can be provided it request authentication is desired.
 

--- a/scripts/WindowsDomainCluster/Start-Client.ps1
+++ b/scripts/WindowsDomainCluster/Start-Client.ps1
@@ -71,10 +71,10 @@ $Sb = {
     }
 
     
-    $Cmd = "$ClientPath -mem $MemorySize -verbose $LogLevel -port $Port -jobport $JobPortRange"
+    $Cmd = "$ClientPath -mem $MemorySize -verbose $LogLevel -port $Port -jobports $JobPortRange"
     if ($LogDir)
     {
-        $Cmd = $Cmd + " -dirlog $LogDir"
+        $Cmd = $Cmd + " -logdir $LogDir"
     }
     if ($Password)
     {

--- a/src/CoreLib/CoreLib.fsproj
+++ b/src/CoreLib/CoreLib.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -30,7 +30,6 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debugx64\Prajna.XML</DocumentationFile>
     <PlatformTarget>x64</PlatformTarget>
-    <StartArguments>-mem 48000 -verbose 7 -dirlog c:\Prajna\Log\JinL -homein JINL4 -port 1002 -jobport 1100,1149</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <DebugType>pdbonly</DebugType>

--- a/src/CoreLib/LocalCluster.fs
+++ b/src/CoreLib/LocalCluster.fs
@@ -74,9 +74,9 @@ type internal LocalCluster (name, version, numClients, containerMode, clientPath
         let dirLog = Path.Combine( [| DeploymentSettings.LogFolder; "LocalCluster"; name; "Client-" + ((string)client.MachinePort) |] )
         let args = [ "-mem"; "48000"; 
                      "-verbose"; ((int ) DeploymentSettings.LocalClusterTraceLevel).ToString();
-                     "-dirlog"; dirLog;
+                     "-logdir"; dirLog;
                      "-port";  (string)client.MachinePort;
-                     "-jobport"; sprintf "%i-%i" client.JobPortMin client.JobPortMax;
+                     "-jobports"; sprintf "%i-%i" client.JobPortMin client.JobPortMax;
                      "-local"  ]
         let allArgs = if containerMode = LocalClusterContainerMode.AppDomain then "-allowad"::args else args
         Array.ofList allArgs    

--- a/src/CoreLib/task.fs
+++ b/src/CoreLib/task.fs
@@ -290,7 +290,7 @@ and [<AllowNullLiteral>]
                         if Utils.IsNotNull nodeInfo then 
                             let proc = Process.GetCurrentProcess()
                             let clientInfo = sprintf "-clientId %i -clientModuleName %s -clientStartTimeTicks %i" proc.Id proc.MainModule.ModuleName proc.StartTime.Ticks
-                            let mutable cmd_line = sprintf "-job %s -ver %d -ticks %d -loopback %d -jobport %d -mem %d -dirlog %s -verbose %d %s" x.SignatureName x.SignatureVersion executeTicks DeploymentSettings.ClientPort nodeInfo.ListeningPort DeploymentSettings.MaxMemoryLimitInMB DeploymentSettings.LogFolder (int Prajna.Tools.Logger.DefaultLogLevel) clientInfo
+                            let mutable cmd_line = sprintf "-job %s -ver %d -ticks %d -loopback %d -jobport %d -mem %d -logdir %s -verbose %d %s" x.SignatureName x.SignatureVersion executeTicks DeploymentSettings.ClientPort nodeInfo.ListeningPort DeploymentSettings.MaxMemoryLimitInMB DeploymentSettings.LogFolder (int Prajna.Tools.Logger.DefaultLogLevel) clientInfo
                             if DeploymentSettings.StatusUseAllDrivesForData then 
                                 cmd_line <- "-usealldrives " + cmd_line
                             if not (DeploymentSettings.ClientIP.Equals("")) then
@@ -3568,7 +3568,7 @@ type internal ContainerLauncher() =
         let argv = Array.copy orgargv
         let firstParse = ArgumentParser(argv, false)
 
-        let logdir = firstParse.ParseString( "-dirlog", (DeploymentSettings.LogFolder) )
+        let logdir = firstParse.ParseString( "-logdir", (DeploymentSettings.LogFolder) )
         let name = firstParse.ParseString( "-job", "" )
         let ticks = firstParse.ParseInt64( "-ticks", (DateTime.MinValue.Ticks) )
         let logFileName = Path.Combine( logdir, name + "_exe_" + VersionToString( DateTime(ticks) ) + ".log"  )

--- a/src/ServiceLib/BasicService/BasicService.fsproj
+++ b/src/ServiceLib/BasicService/BasicService.fsproj
@@ -30,7 +30,6 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debugx64\Prajna.BasicService.XML</DocumentationFile>
     <PlatformTarget>x64</PlatformTarget>
-    <StartArguments>-mem 48000 -verbose 7 -dirlog c:\BasicService\Log\JinL -homein JINL4 -port 1002 -jobport 1100,1149</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <DebugType>pdbonly</DebugType>

--- a/src/ServiceLib/ServiceEndpoint/ServiceEndpoint.fsproj
+++ b/src/ServiceLib/ServiceEndpoint/ServiceEndpoint.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -30,7 +30,6 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debugx64\Prajna.Service.ServiceEndpoint.XML</DocumentationFile>
     <PlatformTarget>x64</PlatformTarget>
-    <StartArguments>-mem 48000 -verbose 7 -dirlog c:\PrajnaQueryService\Log\JinL -homein JINL4 -port 1002 -jobport 1100,1149</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <DebugType>pdbonly</DebugType>

--- a/tests/Common/TestEnvironment.fs
+++ b/tests/Common/TestEnvironment.fs
@@ -23,11 +23,11 @@ type TestEnvironment private () =
 
     do
         Environment.Init()
-        let dirLog = Path.Combine ([| DeploymentSettings.LocalFolder; "Log"; "UnitTest" |])
-        let fileLog = Path.Combine( dirLog, "UnitTestApp_" + StringTools.UtcNowToString() + ".log" )
+        let logdir = Path.Combine ([| DeploymentSettings.LocalFolder; "Log"; "UnitTest" |])
+        let fileLog = Path.Combine( logdir, "UnitTestApp_" + StringTools.UtcNowToString() + ".log" )
         let args = [| "-verbose"; "5"; 
                        "-log"; fileLog |]
-        let dirInfo= FileTools.DirectoryInfoCreateIfNotExists dirLog
+        let dirInfo= FileTools.DirectoryInfoCreateIfNotExists logdir
         let dirs = dirInfo.GetDirectories()
          // Remove related versions. 
         for dir in dirs do


### PR DESCRIPTION
For launch client, use "logdir" instead of "dirlog", "jobports" instead of "jobport". But "dirlog" and "jobport" are still supported to not break existing scripts.
