### PR TITLE
Adding Fletcher64 hashing to replace SHA256

### DIFF
--- a/samples/examples/FSharpExamples/NaiveBayes.fs
+++ b/samples/examples/FSharpExamples/NaiveBayes.fs
@@ -255,7 +255,7 @@ type NaiveBayes() =
  
 //        let stream = new MemoryStream()
         let stream = new MemStream()
-        let serializer = new BinarySerializer() :> System.Runtime.Serialization.IFormatter
+        let serializer = GenericSerialization.GetFormatter GenericSerialization.PrajnaFormatterGuid
         sw.Restart()
 //        stream.SerializeFrom seqCounts
         serializer.Serialize(stream, seqCounts)

--- a/src/CoreLib/DSeq.fs
+++ b/src/CoreLib/DSeq.fs
@@ -307,7 +307,7 @@ and [<AllowNullLiteral>]
         curStream.DecodeUpStreamDependency( readStream ) 
         let endpos = readStream.Position
         // Recover hash
-        curStream.Hash <- readStream.ComputeSHA256(startpos, endpos-startpos)
+        curStream.Hash <- readStream.ComputeChecksum(startpos, endpos-startpos)
         //curStream.Hash <- HashByteArrayWithLength( buf, int startpos, int (endpos-startpos) )
         Logger.LogF( LogLevel.MildVerbose, (fun _ -> sprintf "Decode DStream %s:%s, Hash = %s" curStream.Name curStream.VersionString (BytesToHex(curStream.Hash)) ))
         curStream.DecodeDownStreamDepedency( readStream ) 

--- a/src/CoreLib/DSet.fs
+++ b/src/CoreLib/DSet.fs
@@ -206,7 +206,7 @@ and [<Serializable; AllowNullLiteral>]
     let mutable reportReceived = lazy( Array.create thisDSet.Cluster.NumNodes false )
     /// A dictionary that holds key, values that is used to confirm the successful store of DSet. 
     /// If a certain peer becomes unavailable, we may choose to redelivery the elem
-    /// Key: byte[], SHA256 hash of the elem stream to be stored. 
+    /// Key: byte[], hash (Fletcher64 currently) of the elem stream to be stored. 
     /// Value: < Time: in CLock.ElapsedTicks, 
     ///          parti: partition value (used for redelivery
     ///          byte[]: the byte sent by the network queue 
@@ -1092,8 +1092,7 @@ and [<Serializable; AllowNullLiteral>]
         /// Get hash
         let endpos = readStream.Position
         //curDSet.Hash <- HashByteArrayWithLength( buf, int startpos, int (endpos-startpos))
-        curDSet.Hash <- readStream.ComputeSHA256(startpos, endpos-startpos)
-        //let b2 = readStream.ComputeSHA256(startpos, endpos-startpos)
+        curDSet.Hash <- readStream.ComputeChecksum(startpos, endpos-startpos)
         Logger.LogF( LogLevel.MildVerbose, (fun _ -> sprintf "Decode DSet %s:%s, Hash = %s (%d-%d)" curDSet.Name curDSet.VersionString (BytesToHex(curDSet.Hash)) startpos endpos ))
         curDSet.DecodeDownStreamDependency( readStream )
         curDSet

--- a/src/CoreLib/dependency.fs
+++ b/src/CoreLib/dependency.fs
@@ -55,7 +55,9 @@ type internal JobDependency() =
     /// we use the last 8B of Hash as signature
     member x.ComputeHash( buf: byte[] ) = 
         if (Utils.IsNull x.Hash) then
-            x.Hash <- HashLengthPlusByteArray( buf )
+            x.Hash <- 
+                use hasher = new System.Security.Cryptography.SHA256Managed()
+                HashLengthPlusByteArray( hasher, buf )
         x.Hash
 
     /// Compute hash based on current file 
@@ -257,7 +259,6 @@ type JobDependencies() =
             ms.WriteBytes( dep.Hash ) |> ignore 
         let (buf, pos, cnt) = ms.GetBufferPosLength()
         x.Hash <- ms.ComputeSHA256(int64 pos, int64 cnt)
-        //x.Hash <- HashByteArrayWithLength( ms.GetBufferPosLength() )
         ms.DecRef()
         x.Hash
 

--- a/src/Toolkit/RemoteCopy/RemoteCopy.fs
+++ b/src/Toolkit/RemoteCopy/RemoteCopy.fs
@@ -176,7 +176,9 @@ let calculateFileHash( fileLst:ConcurrentDictionary<FileInfo, byte[]>) =
         try
             let byt = ReadBytesFromFile pair.Key.FullName
             count <- count + int64 byt.Length
-            let res32 = HashLengthPlusByteArray( byt )
+            let res32 = 
+                use hasher = new System.Security.Cryptography.SHA256Managed()
+                HashLengthPlusByteArray( hasher, byt )
             fileLst.Item( pair.Key ) <- res32
             Logger.LogF( LogLevel.MildVerbose, ( fun _ -> sprintf "File %s Hash = %s" pair.Key.FullName (BytesToHex(res32)) ))
         with 
@@ -212,7 +214,9 @@ let remoteCopyOps (hashPath:string) (remotePath:string) (copyContent:(string*int
                 FileTools.WriteBytesToFileConcurrent filename byt
                 File.SetLastWriteTimeUtc( filename, DateTime( ticks ) ) 
                 if not (StringTools.IsNullOrEmpty( hashPath )) then 
-                    let res32 = HashLengthPlusByteArray( byt ) 
+                    let res32 = 
+                        use hasher = new System.Security.Cryptography.SHA256Managed()
+                        HashLengthPlusByteArray( hasher, byt ) 
                     let res32String = BytesToHex(res32) + ".hlnk"
                     let linkedFilename = Path.Combine( hashPath, res32String ) 
                     InteropWithKernel32.CreateHardLink( linkedFilename, filename, IntPtr.Zero ) |> ignore

--- a/src/tools/tools/AssemblyProperties.fs
+++ b/src/tools/tools/AssemblyProperties.fs
@@ -54,6 +54,8 @@ module internal AssemblyProperties =
 
     [<assembly: InternalsVisibleTo("Prajna.BasicService" )>]
     
+    [<assembly: InternalsVisibleTo("Prajna.Tools.Tests" )>]
+    
     // Temporary! PrajnaCopy is currently using internal stuff
     [<assembly: InternalsVisibleTo("PrajnaCopy" )>]
     // Temporary! SortBenchmark is currently using internal stuff

--- a/src/tools/tools/Tools.fsproj
+++ b/src/tools/tools/Tools.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -33,6 +33,7 @@
     <Compile Include="AssemblyProperties.fs" />
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="utils.fs" />
+    <Compile Include="hash.fs" />
     <Compile Include="interops.fs" />
     <Compile Include="Math.fs" />
     <Compile Include="extension.fs" />

--- a/src/tools/tools/bufferliststream.fs
+++ b/src/tools/tools/bufferliststream.fs
@@ -560,8 +560,12 @@ type [<AllowNullLiteral>] [<AbstractClass>] StreamBase<'T> =
         x.ComputeHash(sha512, offset, len)
 
     member x.ComputeSHA256(offset : int64, len : int64) =
-        use sha256managed = new Security.Cryptography.SHA256Managed()
-        x.ComputeHash(sha256managed, offset, len)
+        use sha256 = new Security.Cryptography.SHA256Managed() 
+        x.ComputeHash(sha256, offset, len)
+
+    member x.ComputeChecksum(offset : int64, len : int64) =
+        use hasher = Hash.CreateChecksum()
+        x.ComputeHash(hasher, offset, len)
 
     member internal x.WriteUInt128( data: UInt128 ) = 
         x.WriteUInt64( data.Low )

--- a/src/tools/tools/bytes.fs
+++ b/src/tools/tools/bytes.fs
@@ -61,7 +61,7 @@ type BytesCompare =
                 for v in x do 
                     hash <- ( hash * 31 ) ^^^ ( int v)
                 hash
-                
+
 /// <summary>
 /// A set of helper routine for byte[] operations
 /// </summary>
@@ -103,23 +103,22 @@ module  BytesTools =
 
     /// Compute Hash of the bytearray
     let HashByteArray( data: byte[] ) = 
-        let sha256managed = new SHA256Managed()
-        let result = sha256managed.ComputeHash( data )
+        let hasher = Hash.CreateChecksum()
+        let result = hasher.ComputeHash( data )
         result
 
     /// <summary>
     /// Calculate a hash that matches the file hash in PrajnaRemote execution roster. The calculdated hash include 
     /// length of byte[] plus the content of the byte[].
     /// </summary>
-    let inline HashLengthPlusByteArray( data: byte[] ) = 
-        let sha256managed = new SHA256Managed()
+    let HashLengthPlusByteArray( hasher: HashAlgorithm, data: byte[] ) = 
         let len = if Utils.IsNull data then 0 else data.Length
         let lenarr = BitConverter.GetBytes( len ) 
-        sha256managed.TransformBlock( lenarr, 0, lenarr.Length, lenarr, 0 ) |> ignore
+        hasher.TransformBlock( lenarr, 0, lenarr.Length, lenarr, 0 ) |> ignore
         if len > 0 then 
-            sha256managed.TransformBlock( data, 0, len, data, 0 ) |> ignore
-        sha256managed.TransformFinalBlock( [||], 0, 0 ) |> ignore
-        sha256managed.Hash
+            hasher.TransformBlock( data, 0, len, data, 0 ) |> ignore
+        hasher.TransformFinalBlock( [||], 0, 0 ) |> ignore
+        hasher.Hash
 
     /// Compute Hash of the bytearray, and use first 16B of hash to form a GUID
     let inline HashByteArrayToGuid( data: byte[] ) = 
@@ -128,8 +127,8 @@ module  BytesTools =
         System.Guid( result )
 
     let internal HashByteArrayWithLength( data: byte[], offset, count ) = 
-        let sha256managed = new SHA256Managed()
-        let result = sha256managed.ComputeHash( data, offset, count )
+        let hasher = Hash.CreateChecksum()
+        let result = hasher.ComputeHash( data, offset, count )
         result
 
     let inline internal HashByteArrayToGuidWithLength( data: byte[], offset, count ) = 

--- a/src/tools/tools/hash.fs
+++ b/src/tools/tools/hash.fs
@@ -1,0 +1,197 @@
+﻿namespace Prajna.Tools
+
+#nowarn "9"
+    
+open System
+open System.Runtime.InteropServices
+open System.Security.Cryptography
+
+open FSharp.NativeInterop
+
+module Hash =
+
+    open System.Collections.Generic
+
+//    let inline safeItersWithoutOverflow maxShortAsLong = 
+//        let sums = 
+//            seq {
+//                let mutable sum1 = maxShortAsLong
+//                let mutable sum2 = maxShortAsLong
+//                while true do
+//                    sum1 <- sum1 + maxShortAsLong
+//                    sum2 <- sum2 + sum1
+//                    sum1 <- sum1 + maxShortAsLong
+//                    sum2 <- sum2 + sum1
+//                    yield sum2
+//            }
+//        sums 
+//        |> Seq.pairwise
+//        |> Seq.takeWhile (fun (a,b) -> a < b)
+//        |> Seq.length
+    [<Literal>] 
+    let safeIntItersWithoutOverflow = 46337 // safeItersWithoutOverflow 0xFFFFFFFFUL - 2
+
+    let inline ( ~% ) (ptr: nativeptr<'T>) = NativePtr.read ptr 
+    let inline ( &+ ) (ptr: nativeptr<'T>) (index: int) = NativePtr.add ptr index
+
+    type nativeptr<'T when 'T : unmanaged> with
+        member inline this.Item(i: int) = NativePtr.get this i
+
+
+    // Hashes a byte stream by interpreting it as a sequence of 32-bit uints,
+    // computing its sum and cummulative sum modulo 2^32-1, 
+    // and returning cumSum <<< 32 || sum
+    type internal Fletcher64() =
+        inherit HashAlgorithm()
+
+#if VERIFY_HASH
+        static let sha256s = new HashSet<Guid>()
+        static let f64s = new HashSet<Guid>()
+        let inner = new SHA256Managed()
+#endif
+
+        // We use uint64s storage for speed and convenience, but before we return,
+        // each is taken modulo 2^32-1 and stacked together in a single 64-bit result
+        // By convention, sum1 is the regular sum and sum2 the cummulative sum
+        let mutable sum1 = 0xFFFFFFFFUL
+        let mutable sum2 = 0xFFFFFFFFUL
+        let mutable edgeBytesDone = 0
+        let mutable edgeBytes = 0UL
+        let mutable totalSize = 0UL
+
+        let reset() = 
+            sum1 <- 0xFFFFFFFFUL
+            sum2 <- 0xFFFFFFFFUL
+            edgeBytesDone <- 0
+            edgeBytes <- 0UL
+
+        let doMod() = 
+            // Faster way to do sum % (2^32-1)
+            sum1 <- (sum1 &&& 0xFFFFFFFFUL) + (sum1 >>> 32) 
+            sum2 <- (sum2 &&& 0xFFFFFFFFUL) + (sum2 >>> 32)
+
+        let addEdgeBytes() = 
+            // since we use a long pointer to fetch ints from the byte array,
+            // the first int (in byte array index order) is in the low part
+            // so we sum that first
+            sum1 <- sum1 + (edgeBytes &&& 0xFFFFFFFFUL)
+            sum2 <- sum2 + sum1
+            sum1 <- sum1 + (edgeBytes >>> 32)
+            sum2 <- sum2 + sum1
+            doMod() 
+
+        let addEdge (bytePtr: nativeptr<byte>) (edgeLen: int)= 
+            assert(edgeBytesDone < 8)
+            assert(0 < edgeLen && edgeLen < 8)
+            let mutable i = 0
+            // load Big-endian uint32s, byte by byte, into the edgeBytes uint64
+            // the first int, in byte array order, will end up in the low part of edgeBytes
+            while i < edgeLen do
+                edgeBytes <- (edgeBytes >>> 8) ||| (uint64 bytePtr.[i] <<< 56)
+                edgeBytesDone <- edgeBytesDone + 1
+                i <- i + 1
+            assert (edgeBytesDone <= 8)
+            if edgeBytesDone = 8 then 
+                do addEdgeBytes()
+                do doMod()
+                edgeBytesDone <- 0
+                edgeBytes <- 0UL
+
+        let fletcher64 (voidPtr: nativeint) (voidPtrLen: int) : unit =
+
+            let bytePtr, bytesLen = 
+                if edgeBytesDone > 0 then
+                    let bytePtr = NativePtr.ofNativeInt<byte> voidPtr
+                    let edgeSize = min voidPtrLen (8 - edgeBytesDone)
+                    addEdge bytePtr edgeSize
+                    bytePtr &+ edgeSize, voidPtrLen - edgeSize
+                else
+                    NativePtr.ofNativeInt<byte> voidPtr, voidPtrLen
+
+            if bytesLen > 0 then
+                let bytePtr, bytesLen =
+                    let longPtr = NativePtr.toNativeInt bytePtr |> NativePtr.ofNativeInt<uint64>
+                    let numLongs = bytesLen / 8
+                    for blockStart in 0 .. safeIntItersWithoutOverflow .. (numLongs - 1) do
+                        let timesInner = min safeIntItersWithoutOverflow (numLongs - blockStart)
+                        // Copy to locals to ensure enregistration. Yields major perf improvement (> 60%).
+                        let mutable localSum1 = sum1
+                        let mutable localSum2 = sum2
+                        for pos = blockStart to (blockStart + timesInner - 1) do
+                            let long = longPtr.[pos]
+                            // Add low part first (first int), then high part
+                            localSum1 <- localSum1 + (long &&& 0xFFFFFFFFUL)
+                            localSum2 <- localSum2 + localSum1
+                            localSum1 <- localSum1 + (long >>> 32)
+                            localSum2 <- localSum2 + localSum1
+                        sum1 <- localSum1
+                        sum2 <- localSum2
+                        do doMod()
+                    let bytesDone = 8 * numLongs
+                    bytePtr &+ bytesDone, bytesLen - bytesDone
+
+                assert (bytesLen < 8)
+                if bytesLen > 0 then
+                    addEdge bytePtr bytesLen
+
+        override this.Initialize() = reset()
+
+        override this.HashCore(arr: byte[], offset: int, count: int) = 
+            assert (offset >= 0)
+            assert (count >= 0)
+            assert (offset + count <= if arr = null then 0 else arr.Length)
+#if VERIFY_HASH
+            inner.TransformBlock(arr, offset, count, null, 0) |> ignore
+#endif
+            if edgeBytesDone = -1 then
+                raise <| InvalidOperationException("TransformBlock(...) not supported after Finish()")
+            if count > 0 then
+                totalSize <- totalSize + uint64 count
+                let handle = GCHandle.Alloc(arr, GCHandleType.Pinned)
+                try
+                    let ptr = NativePtr.ofNativeInt<byte> <| handle.AddrOfPinnedObject()
+                    fletcher64 (NativePtr.toNativeInt (ptr &+ offset)) count
+                finally
+                    handle.Free() 
+
+
+        override this.HashFinal() : byte[] = 
+#if VERIFY_HASH
+            inner.TransformFinalBlock([||], 0, 0) |> ignore
+            let innerHash = inner.Hash 
+#endif
+            this.HashCore(BitConverter.GetBytes(totalSize), 0, sizeof<uint64>)
+            if edgeBytesDone > 0 then
+                edgeBytes <- edgeBytes >>> (8 * (8 - edgeBytesDone))
+                // Even though we read 64 bits at a time, the stream is still interpreted
+                // as 32-bit uints. Therefore, we only zero-pad to the next *uint32*.
+                // Padding to full uint64 would not affect the regular sum (sum1)
+                // but would affect the cummulative sum2.
+                sum1 <- sum1 + (edgeBytes &&& 0xFFFFFFFFUL)
+                sum2 <- sum2 + sum1
+                if edgeBytesDone > 4 then
+                    sum1 <- sum1 + (edgeBytes >>> 32)
+                    sum2 <- sum2 + sum1
+                do doMod()
+            edgeBytesDone <- -1
+            let finalHash = BitConverter.GetBytes(sum2 <<< 32 ||| sum1)
+            //BitConverter.GetBytes(sum2 <<< 32 ||| sum1)
+            // Array.concat [|bytes; bytes; bytes; bytes|]
+#if VERIFY_HASH
+            lock f64s (fun _ ->
+                f64s.Add(Guid(Array.concat [|finalHash; finalHash|])) |> ignore
+                sha256s.Add(Guid(innerHash.[0..15])) |> ignore
+                if f64s.Count <> sha256s.Count then
+                    failwith "Found collision!"
+            )
+#endif
+            finalHash
+
+
+        override this.Dispose(disposing: bool) = 
+#if VERIFY_HASH
+            inner.Dispose()
+#endif
+            base.Dispose(disposing)
+
+    let CreateChecksum() : HashAlgorithm = upcast new Fletcher64()

--- a/src/tools/tools/serialize.fs
+++ b/src/tools/tools/serialize.fs
@@ -711,7 +711,7 @@ type internal ReferenceComparer() =
         member x.GetHashCode(obj: obj): int = 
             System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj)
 
-type BinarySerializer() =
+type internal BinarySerializer() =
 
     interface IFormatter with
         

--- a/tests/tools/tools/Tools.Tests.fsproj
+++ b/tests/tools/tools/Tools.Tests.fsproj
@@ -69,6 +69,7 @@
     <Compile Include="AssemblyProperties.fs" />
     <Compile Include="mem.fs" />
     <Compile Include="serialize.fs" />
+    <Compile Include="hash.fs" />
     <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/tools/tools/hash.fs
+++ b/tests/tools/tools/hash.fs
@@ -1,0 +1,90 @@
+﻿namespace Prajna.Tools.Tests
+
+open System
+open System.Security.Cryptography
+open System.Collections.Generic
+
+open NUnit.Framework
+
+open Prajna.Tools
+open Prajna.Tools.Hash
+
+[<TestFixture(Description = "Tests for hashing")>]
+module HashingTests =
+
+    let hashBlocks (data: byte[]) (blockSizes: int[]) =
+        System.Diagnostics.Debug.Assert(Array.sum blockSizes = data.Length)
+        let f64 : HashAlgorithm = Hash.CreateChecksum()
+        for start,len in Seq.zip (blockSizes |> Seq.scan (+) 0 |> Seq.take blockSizes.Length) blockSizes do
+            f64.TransformBlock(data, start, len, null, 0) |> ignore
+        f64.TransformFinalBlock([||], 0, 0) |> ignore
+        f64.Hash
+
+    let getBytes (data: int[]) = data |> Array.map BitConverter.GetBytes |> Array.concat
+    
+    let hashInts (data: int[]) =
+        let bytes = getBytes data
+        hashBlocks bytes [|bytes.Length|]
+
+    let genBlocks size =
+        let r = new Random(0)
+        seq {
+            while true do
+                let sizes = List<int>()
+                while sizes |> Seq.sum < size do
+                    sizes.Add (r.Next(size + 1))
+                if sizes |> Seq.sum > size then
+                    sizes.[sizes.Count - 1] <- size - (sizes |> Seq.take (sizes.Count - 1) |> Seq.sum)
+                yield (sizes |> Seq.toArray)                
+        } 
+
+    [<Test>]
+    let HashBlockSizes() = 
+        let dataBlocks = 
+            let r = new System.Random(0)
+            [for _ in 1..10 do
+                let data : byte[] = Array.init (r.Next(100) + 1000) (fun _ -> byte <| r.Next(10) + 246)
+                let blockSizes = genBlocks data.Length |> Seq.take 10 |> Seq.toArray
+                yield data, blockSizes]
+        let results = 
+            [for data,blocks in dataBlocks do
+                if blocks.Length > 1 then
+                    let b0 = blocks.[0]
+                    for b in blocks.[1..] do
+                        let h = hashBlocks data b0
+                        yield (h = hashBlocks data b), h]
+        Assert.IsTrue(results |> Seq.map fst |> Seq.forall id)
+
+    [<Test>]
+    let HashKnownValue() = 
+        let data = getBytes [|1; 2|]
+        for blocks in genBlocks data.Length |> Seq.take 100 do
+            let hash =  BitConverter.ToUInt64(hashBlocks data blocks, 0)
+            let lo = hash &&& 0xFFFFFFFFUL
+            let hi = hash >>> 32
+            // BitConverter.GetBytes(uint64 data.Length) is added to the array
+            // so we must sum that up as well
+            Assert.AreEqual(11UL, lo) // 1 + 2 + 8 + 0 = 11
+            Assert.AreEqual(26UL, hi) // 1 + (1 + 2) + (1 + 2 + 8) + (1 + 2 + 8 + 0) = 26
+
+    [<Test>]
+    let HashSamePaddedDataOnlyDifferentLength() = 
+        let data = getBytes [|1; 2; 0; 0; 0|]
+        use f64 = Hash.CreateChecksum()
+        let hashes = Array.init (data.Length + 1) (fun i -> f64.ComputeHash(data, 0, i))
+        for i = 0 to hashes.Length - 1 do
+            for j = i + 1 to hashes.Length - 1 do
+                Assert.AreNotEqual( hashes.[i], hashes.[j] )
+
+    [<Test>]
+    let HashMultipleMods() = 
+        let data =
+            let r = new Random(0)
+            Array.init 200000 (fun _ -> byte <| r.Next(256))
+        let bs = genBlocks data.Length |> Seq.take 2 |> Seq.toArray
+        let b0Hash = hashBlocks data bs.[0]
+        for b in bs.[1..] do
+            Assert.AreEqual(b0Hash, hashBlocks data b)
+
+
+


### PR DESCRIPTION
SHA256 was way overkill what we are doing. This Fletcher64 implementation is more than sufficient for checksuming, over 50x faster, and does around 5GB/s in my machine.
