### PR TITLE
Replaced "Everyone" string with the correct security identifier

### DIFF
--- a/src/tools/tools/Logger.fs
+++ b/src/tools/tools/Logger.fs
@@ -35,6 +35,7 @@ open System.Collections.Concurrent
 open System.Diagnostics
 open System.IO
 open System.Security.AccessControl
+open System.Security.Principal
 open System.Threading
 
 open Prajna.Tools.StringTools
@@ -147,7 +148,8 @@ type internal DefaultLogger () =
         // File created are given full control by everyone, this eases the job of executing file under multiuser scenario
         if not Runtime.RunningOnMono then
             let fSecurity = File.GetAccessControl( useFilename ) 
-            fSecurity.AddAccessRule( new FileSystemAccessRule( "Everyone", FileSystemRights.FullControl, AccessControlType.Allow ) )
+            let everyoneSid = new SecurityIdentifier( WellKnownSidType.WorldSid, null )
+            fSecurity.AddAccessRule( new FileSystemAccessRule( everyoneSid, FileSystemRights.FullControl, AccessControlType.Allow ) )
             File.SetAccessControl( useFilename, fSecurity )
         Trace.Listeners.Add( useListener ) |> ignore 
         if Utils.IsNotNull logListener then 

--- a/src/tools/tools/file.fs
+++ b/src/tools/tools/file.fs
@@ -33,6 +33,7 @@ namespace Prajna.Tools
 open System
 open System.IO
 open System.Security.AccessControl
+open System.Security.Principal
 
 open System.Text
 
@@ -75,7 +76,8 @@ module  FileTools =
     let internal MakeFileAccessible (fname ) = 
         if not Runtime.RunningOnMono then
             let fSecurity = File.GetAccessControl( fname ) 
-            fSecurity.AddAccessRule( new FileSystemAccessRule( "Everyone", FileSystemRights.FullControl, AccessControlType.Allow ) )
+            let everyoneSid = new SecurityIdentifier( WellKnownSidType.WorldSid, null )
+            fSecurity.AddAccessRule( new FileSystemAccessRule( everyoneSid, FileSystemRights.FullControl, AccessControlType.Allow ) )
             File.SetAccessControl( fname, fSecurity )
         else
             // Mono Note: Mono does not support File.GetAccessControl on linux. To-be-investigated

--- a/src/tools/tools/utils.fs
+++ b/src/tools/tools/utils.fs
@@ -32,6 +32,7 @@ namespace Prajna.Tools
 open System
 open System.Runtime.CompilerServices
 open System.Collections.Generic
+open System.Security.Principal
 
 /// <summary>
 /// Construct a comparer that uses Object.ReferenceEquals to compare object. 
@@ -123,16 +124,17 @@ module internal DirUtils =
         else
             let mutable dirInfo = new DirectoryInfo(dir)
             if not dirInfo.Exists then 
+                let everyoneSid = new SecurityIdentifier( WellKnownSidType.WorldSid, null )
                 try 
                     Directory.CreateDirectory(dir) |> ignore
                     if not Runtime.RunningOnMono then
                         let fSecurity = File.GetAccessControl( dir ) 
-                        fSecurity.AddAccessRule( new FileSystemAccessRule( "everyone", FileSystemRights.FullControl, AccessControlType.Allow ) )
+                        fSecurity.AddAccessRule( new FileSystemAccessRule( everyoneSid, FileSystemRights.FullControl, AccessControlType.Allow ) )
                         File.SetAccessControl( dir, fSecurity )
                     dirInfo <- new DirectoryInfo(dir)
                     if not Runtime.RunningOnMono then
                         let dSecurity = dirInfo.GetAccessControl()
-                        dSecurity.AddAccessRule( new FileSystemAccessRule( "Everyone", FileSystemRights.FullControl, AccessControlType.Allow ) )
+                        dSecurity.AddAccessRule( new FileSystemAccessRule( everyoneSid, FileSystemRights.FullControl, AccessControlType.Allow ) )
                         dirInfo.SetAccessControl( dSecurity )
                 with 
                 | e -> 


### PR DESCRIPTION
The "Everyone" string doesn't get the correct user group on non-English Windows installations.

http://stackoverflow.com/questions/4614697/how-to-get-the-identityreference-for-everyone-to-create-mutexaccessrule-on-loc

https://msdn.microsoft.com/en-us/library/system.security.principal.wellknownsidtype(v=vs.110).aspx
