### PR TITLE
Always use MemoryStreamB and reduce memory usage

### DIFF
--- a/samples/examples/FSharpExamples/NaiveBayes.fs
+++ b/samples/examples/FSharpExamples/NaiveBayes.fs
@@ -254,7 +254,7 @@ type NaiveBayes() =
         let sw = new Stopwatch()
  
 //        let stream = new MemoryStream()
-        let stream = new MemStream()
+        use stream = new MemStream()
         let serializer = GenericSerialization.GetFormatter GenericSerialization.PrajnaFormatterGuid
         sw.Restart()
 //        stream.SerializeFrom seqCounts
@@ -273,7 +273,7 @@ type NaiveBayes() =
         printfn "----------------------------------"
 
         printfn "Using standard .NET BinaryFormatter:"
-        let newStream = new MemStream()
+        use newStream = new MemStream()
         sw.Restart()
         newStream.SerializeFrom(seqCounts)
         let timeSer2 = sw.Stop(); sw.Elapsed

--- a/src/CoreLib/DSetAction.fs
+++ b/src/CoreLib/DSetAction.fs
@@ -356,7 +356,7 @@ type internal DSetAction() =
             let registerDSet = seq { yield! x.RemappedDSet
                                      yield! x.Job.DstDSet }
             for dset in registerDSet do 
-                using ( new MemStream( 1024 )) ( fun msSend -> 
+                using ( new MemStream( 1024 ) ) ( fun msSend -> 
                     let currentWriteID = x.Job.JobID
                     msSend.WriteGuid( currentWriteID )
                     msSend.WriteString( dset.Name ) 

--- a/src/CoreLib/DSetGenerics.fs
+++ b/src/CoreLib/DSetGenerics.fs
@@ -229,7 +229,7 @@ type DSet<'U> () =
                     let kvList = arr.[parti].GetRange(0, wLen)
                     let _, msOutput = codec.EncodeFunc( meta, kvList.ToArray() ) 
                     ms.Append(msOutput)
-                    msOutput.DecRef()
+                    (msOutput :> IDisposable).Dispose()
                     written.[parti] <- written.[parti] + wLen
                     if x.NumReplications<=1 || peers.Length > 1 then 
                         peers |> Array.iter( fun peeri -> 
@@ -246,7 +246,6 @@ type DSet<'U> () =
                         let newpeers = x.CanWrite( parti )
                         if newpeers.[0] >=0 then 
                             writeout( parti, newpeers, bFlush )
-                    ms.DecRef()
 
             o |> Seq.iteri ( fun i elem -> 
                     let parti = x.PartitionFunc( elem, x.NumPartitions )

--- a/src/CoreLib/DSetPeer.fs
+++ b/src/CoreLib/DSetPeer.fs
@@ -223,6 +223,7 @@ and [<AllowNullLiteral>]
                 if peerIdx>=0 && bActivePeer.[peerIdx] then 
                     bActivePartitions.[parti] <- true    
         bActivePartitions
+
     /// Deserlization of dset
     /// A copy of input stream ms is made so that if the deserialization is unsuccessful with some missing argument, the missing argument be requested from communication partner. 
     /// After that, the ms stream can be attempted to be unpacked again. 
@@ -231,44 +232,23 @@ and [<AllowNullLiteral>]
         let sendStream = new MemStream( 1024 )
         try 
             // Source DSet ( used by DSetPeer ), always do not instantiate function. 
-                let curDSet = DSet.Unpack( readStream, false )
-//            let storeDSet = DSetPeerFactory.ResolveDSetPeer( curDSet.Name, curDSet.Version.Ticks )
-//            let compVal = if Utils.IsNotNull storeDSet then (storeDSet :> IComparable<DSet> ).CompareTo( curDSet ) else 1
-//            if compVal=0 then 
-//                    // Use storeDSet, release the memory associated with curDSet
-//                    // This is usually happen as multiple peers send DSet to the current node
-//                    // Confirmation message: send Name + version
-//                if Utils.IsNotNull hostQueue then 
-//                    storeDSet.AddCommandQueue( hostQueue )
-//                sendStream.WriteString( curDSet.Name )
-//                sendStream.WriteInt64( curDSet.Version.Ticks )
-//                ( Some( storeDSet) , ClientBlockingOn.None, sendStream )
-//            else
-//                if Utils.IsNotNull storeDSet then 
-//                    // Multiple entries of DSetPeer found with same name, but different content 
-//                    // We have received an update of the DSet 
-//                    DSetPeerFactory.Remove( curDSet.Name + curDSet.VersionString )
-                if ( Utils.IsNull curDSet.Cluster ) then 
-                    sendStream.WriteGuid( jobID )
-                    sendStream.WriteString( curDSet.Name )
-                    sendStream.WriteInt64( curDSet.Version.Ticks )
-                    ( None, ClientBlockingOn.Cluster, sendStream )
-                else
-                    let dsetPeer = DSetPeer( curDSet.Cluster )
-                    dsetPeer.CopyMetaData( curDSet, DSetMetadataCopyFlag.Copy )
-//                    DSetPeerFactory.CacheDSetPeer( dsetPeer )  |> ignore
-                    // Confirmation message: send Name + version
-                    sendStream.WriteGuid( jobID )
-                    sendStream.WriteString( dsetPeer.Name )
-                    sendStream.WriteInt64( dsetPeer.Version.Ticks )
-                    if Utils.IsNotNull hostQueue then 
-                        dsetPeer.AddCommandQueue( hostQueue )
-                    ( Some( dsetPeer) , ClientBlockingOn.None, sendStream )
-//                    let msg = (sprintf "Multiple DSetPeer with same name %s, but different content found in DSetPeerFactory" (curDSet.Name + curDSet.VersionString) )
-//                    Logger.Log(LogLevel.Error, msg)
-//                    // Error message is just a string
-//                    sendStream.WriteString( msg )
-//                    ( None, ClientBlockingOn.Undefined, sendStream )                   
+            let curDSet = DSet.Unpack( readStream, false )
+            if ( Utils.IsNull curDSet.Cluster ) then 
+                sendStream.WriteGuid( jobID )
+                sendStream.WriteString( curDSet.Name )
+                sendStream.WriteInt64( curDSet.Version.Ticks )
+                ( None, ClientBlockingOn.Cluster, sendStream )
+            else
+                let dsetPeer = DSetPeer( curDSet.Cluster )
+                dsetPeer.CopyMetaData( curDSet, DSetMetadataCopyFlag.Copy )
+    //                    DSetPeerFactory.CacheDSetPeer( dsetPeer )  |> ignore
+                // Confirmation message: send Name + version
+                sendStream.WriteGuid( jobID )
+                sendStream.WriteString( dsetPeer.Name )
+                sendStream.WriteInt64( dsetPeer.Version.Ticks )
+                if Utils.IsNotNull hostQueue then 
+                    dsetPeer.AddCommandQueue( hostQueue )
+                ( Some( dsetPeer) , ClientBlockingOn.None, sendStream )                  
         with       
         | ex -> 
             let msg = (sprintf "Job %A DSetPeer.Unpack encounter exception %A" jobID ex )
@@ -284,12 +264,12 @@ and [<AllowNullLiteral>]
     /// Read from Meta Data file
     static member ReadFromMetaData( stream:Stream, useHostQueue, jobID ) = 
         let byte = BytesTools.ReadToEnd stream
-        let ms = new MemStream( byte, 0, byte.Length, false, true )
+        use ms = new MemStream( byte, 0, byte.Length, false, true )
         DSetPeer.Unpack( ms, false, useHostQueue, jobID )
     /// Read from Meta Data file
     static member ReadFromMetaData( name, useHostQueue, jobID ) = 
         let byte = FileTools.ReadBytesFromFile name
-        let ms = new MemStream( byte, 0, byte.Length, false, true )
+        use ms = new MemStream( byte, 0, byte.Length, false, true )
         DSetPeer.Unpack( ms, false, useHostQueue, jobID )
     member x.Setup( ) = 
         let msSend = new MemStream( 1024 )
@@ -319,7 +299,6 @@ and [<AllowNullLiteral>]
             msSend.WriteString( x.Name ) 
             msSend.WriteInt64( x.Version.Ticks )
             ( ControllerCommand( ControllerVerb.Acknowledge, ControllerNoun.DSet ), msSend )
-    
 
     /// Construct meta Data name.
     member x.MetaDataName() = 
@@ -466,6 +445,7 @@ and [<AllowNullLiteral>]
                     Logger.Log( LogLevel.Error, msg )
                     let msError = new MemStream( 1024 )
                     msError.WriteString( (UtcNowToString()) + ":" + msg )
+                    (msSend :> IDisposable).Dispose()
                     ( ControllerCommand( ControllerVerb.Error, ControllerNoun.Message), msError ) 
                 elif seenWriteDSet.[parti].ContainsKey( serial, bufRcvdLen-curBufPos ) then 
                     // Deduplicate DSet received
@@ -504,6 +484,7 @@ and [<AllowNullLiteral>]
                             let cStream = new CryptoStream( msCrypt, tdes.CreateEncryptor(tdes.Key,tdes.IV), CryptoStreamMode.Write)
                             let sWriter = new BinaryWriter( cStream ) 
                             sWriter.Write( ms.GetBuffer(), curBufPos, (bufRcvdLen - curBufPos) )
+                            (ms :> IDisposable).Dispose()
                             sWriter.Close()
                             cStream.Close()
                             ( msCrypt :> StreamBase<byte>, 0, int msCrypt.Length )
@@ -522,6 +503,7 @@ and [<AllowNullLiteral>]
                     streamPartWrite.Write( BitConverter.GetBytes( outputLen ), 0, 4 )
                     //streamPartWrite.Write( writeBuf, writepos, writecount )
                     writeMs.ReadToStream(streamPartWrite, int64 writepos, int64 writecount)
+                    (writeMs :> IDisposable).Dispose()
                     // Written confirmation
                     Logger.Log( LogLevel.MediumVerbose, ( sprintf "Write DSet partition %d, serial %d:%d (rep:%A)" parti serial numElems bReplicateWrite))
                     if x.ConfirmDelivery then 
@@ -532,7 +514,7 @@ and [<AllowNullLiteral>]
                     // streamPartWrite.Flush()
                     if bReplicateWrite then 
                         if Utils.IsNotNull x.HostQueue && x.HostQueue.CanSend then 
-                            let msInfo = new MemStream( 1024 )
+                            use msInfo = new MemStream( 1024 )
                             msInfo.WriteString( x.Name )
                             msInfo.WriteInt64( x.Version.Ticks )
                             msInfo.WriteVInt32( parti ) 
@@ -549,6 +531,7 @@ and [<AllowNullLiteral>]
                 let msg = sprintf "Write DSet Error (inner loop), part %d, serial %d:%d with exception %A" parti serial numElems e 
                 Logger.Log( LogLevel.Error, msg )
                 msError.WriteString( msg ) 
+                (msSend :> IDisposable).Dispose()
                 ( ControllerCommand( ControllerVerb.Error, ControllerNoun.Message), msError ) 
         with
         | e ->
@@ -556,7 +539,9 @@ and [<AllowNullLiteral>]
             let msg = sprintf "Write DSet Error (outer loop), with exception %A" e 
             Logger.Log( LogLevel.Error, msg )
             msError.WriteString( msg ) 
+            (msSend :> IDisposable).Dispose()
             ( ControllerCommand( ControllerVerb.Error, ControllerNoun.Message), msError ) 
+
     member x.CloseStream( parti ) = 
         if Utils.IsNotNull x.BufferedStreamArray then 
             if Utils.IsNotNull x.BufferedStreamArray.[parti] then 
@@ -639,6 +624,7 @@ and [<AllowNullLiteral>]
             let msg = sprintf "EndPartition encounter exception %A " e
             Logger.Log( LogLevel.Error, msg )
             msError.WriteString( msg )
+            (msSend :> IDisposable).Dispose()
             ( ControllerCommand( ControllerVerb.Error, ControllerNoun.Message ), msError )
 
     /// Close DSet
@@ -693,10 +679,13 @@ and [<AllowNullLiteral>]
             let msg = sprintf "Close DSet encounter exception %A " e
             Logger.Log( LogLevel.Error, msg )
             msError.WriteString( msg )
+            (msSend :> IDisposable).Dispose()
             ( ControllerCommand( ControllerVerb.Error, ControllerNoun.Message ), msError )
+
     member private x.PostCloseAllStreamsImpl( jbInfo ) = 
         x.PostCloseAllStreamsBaseImpl( jbInfo )
         x.CloseAllStreams( true )
+
     member private x.CloseAllStreamsImpl( bUpStream ) = 
         lock( x ) ( fun _ -> 
         x.NumReadJobs <- Math.Max( x.NumReadJobs - 1, 0 )
@@ -756,21 +745,16 @@ and [<AllowNullLiteral>]
                 let msg = sprintf "Peer %d: try connect to ... %A" x.CurPeerIndex peerList
                 if Utils.IsNotNull x.HostQueue && x.HostQueue.CanSend then 
                     using ( new MemStream(1024) ) ( fun msInfo -> 
-                    msInfo.WriteString( msg )
-                    x.HostQueue.ToSend( ControllerCommand( ControllerVerb.Verbose, ControllerNoun.Message), msInfo )
+                        msInfo.WriteString( msg )
+                        x.HostQueue.ToSend( ControllerCommand( ControllerVerb.Verbose, ControllerNoun.Message), msInfo )
                     )
                 msg
             Logger.LogF( LogLevel.ExtremeVerbose, extremeTrack )
         ()
+
     // Replicating ms Stream, with start position bufPos to the replicating peers. 
     member x.ReplicateDSet( ms: StreamBase<byte>, bufPos  ) = 
-        //let bufRcvd = ms.GetBuffer()
-        //let bufRcvdLen = int ms.Length
-        //let curPos = int ms.Position
-        // Parsing should start at the current position
-        // replication need to restart from bufPos. 
-        //let peekStream = new MemStream( bufRcvd, curPos, bufRcvdLen-curPos, false, true )
-        let peekStream = new MemStream()
+        use peekStream = new MemStream()
         peekStream.AppendNoCopy(ms, ms.Position, ms.Length-ms.Position)
         let parti = peekStream.ReadVInt32()
         let serial = peekStream.ReadInt64()
@@ -797,6 +781,7 @@ and [<AllowNullLiteral>]
             Logger.Log( LogLevel.Error, msg )
             msError.WriteString( msg )
             ( ControllerCommand( ControllerVerb.Error, ControllerNoun.Message ), msError )
+
     /// Try to sent out replication stream
     member x.TryReplicate( ) = 
         let peerTimeOut = List<int>() 
@@ -826,9 +811,9 @@ and [<AllowNullLiteral>]
                                 // Connection status check 
                                 let extremeTrack() =
                                     let msg = sprintf "Connected from peer %d --> %s" x.CurPeerIndex ( SeqToString( ";", connectedPeerList ) )
-                                    let msInfo = new MemStream( 1024 )
-                                    msInfo.WriteString( msg )
                                     if Utils.IsNotNull x.HostQueue && x.HostQueue.CanSend then 
+                                        use msInfo = new MemStream( 1024 )
+                                        msInfo.WriteString( msg )
                                         x.HostQueue.ToSend( ControllerCommand( ControllerVerb.Verbose, ControllerNoun.Message ), msInfo )
                                     msg
                                 Logger.LogF( LogLevel.ExtremeVerbose, extremeTrack)
@@ -837,10 +822,10 @@ and [<AllowNullLiteral>]
                                  streamToReplicate, int64 streamPos )
                             peerLastActiveTime.[peeri] <- x.Clock.ElapsedTicks  
                             let msg = sprintf "Replicate partition %d, serial %d:%d to peer %d" parti serial numElems peeri
-                            let msInfo = new MemStream(1024)
-                            msInfo.WriteString( msg )
                             Logger.Log( LogLevel.WildVerbose, msg )
                             if Utils.IsNotNull x.HostQueue && x.HostQueue.CanSend then 
+                                use msInfo = new MemStream(1024)
+                                msInfo.WriteString( msg )
                                 x.HostQueue.ToSend( ControllerCommand( ControllerVerb.Info, ControllerNoun.Message ), msInfo )
                             // Make sure we don't replicate again
                             peerList.Remove( peeri ) |> ignore 
@@ -875,6 +860,7 @@ and [<AllowNullLiteral>]
         else
             // This message is filtered out. 
             ( ControllerCommand( ControllerVerb.Nothing, ControllerNoun.DSet ), null )
+
     /// EndStore: called to end storing operation of a DSet to cloud
     member x.EndReplicate( queue:NetworkCommandQueue, timeToWait, callback ) =
         if not bEndReplicateCalled then 
@@ -922,7 +908,6 @@ and [<AllowNullLiteral>]
     member x.DoEndReplicateWait() = 
         if Utils.IsNotNull callbackRegister then 
             let cmdReplicateClose = ControllerCommand( ControllerVerb.ReplicateClose, ControllerNoun.DSet ) 
-            let mutable msSend : MemStream = null
             let mutable bIOActivity = false
             // Flushing out replication queue. 
             if ( peerReplicationItems.Count>0 || not bAllCloseDSetSent ) && x.Clock.ElapsedTicks<maxEndReplicationWait then
@@ -940,6 +925,9 @@ and [<AllowNullLiteral>]
                         for peeri in peerList do
                             bActivePeers.[peeri] <- true
                 let mutable bTestAllCloseDSetSent = true
+                use msSend = new MemStream( 1024 )
+                msSend.WriteString( x.Name ) 
+                msSend.WriteInt64( x.Version.Ticks )
                 for i=0 to x.Cluster.NumNodes-1 do 
                     // Send a Close DSet command only for active peer. 
                     let q = x.Cluster.Queue( i )
@@ -963,10 +951,6 @@ and [<AllowNullLiteral>]
                                         bTestAllCloseDSetSent <- false
                             else
                                 if not bCloseDSetSent.[i] then 
-                                    if Utils.IsNull msSend then 
-                                        msSend <- new MemStream( 1024 )
-                                        msSend.WriteString( x.Name ) 
-                                        msSend.WriteInt64( x.Version.Ticks )
                                     q.ToSend( cmdReplicateClose, msSend )
                                     bIOActivity <- true 
                                     bCloseDSetSent.[i] <- true
@@ -1038,6 +1022,7 @@ and [<AllowNullLiteral>]
             bIOActivity 
         else
             false
+
     static member EndReplicateWait( o: Object ) = 
         match o with 
         | :? DSetPeer as x ->
@@ -1046,6 +1031,7 @@ and [<AllowNullLiteral>]
             let msg = ( sprintf "Logic error, DSetPeer.EndReplicateWait receives a call with object that is not DSet peer but %A" o )    
             Logger.Log( LogLevel.Error, msg )
             failwith msg
+
     member x.ReplicateDSetCallback( cmd:ControllerCommand, peeri, msRcvd:StreamBase<byte>, jobID ) = 
         try
             let q = x.Cluster.Queue( peeri )
@@ -1057,11 +1043,11 @@ and [<AllowNullLiteral>]
                 // Close DSet received
 //                    bPeerInReplicate.[peeri] <- false
                 bConfirmCloseRcvd.[peeri] <- true
-                let msSend = new MemStream( 1024 )
-                msSend.WriteString( x.Name )
-                msSend.WriteInt64( x.Version.Ticks )
-                msSend.WriteVInt32( peeri )
                 if Utils.IsNotNull x.HostQueue && x.HostQueue.CanSend then 
+                    use msSend = new MemStream( 1024 )
+                    msSend.WriteString( x.Name )
+                    msSend.WriteInt64( x.Version.Ticks )
+                    msSend.WriteVInt32( peeri )
                     x.HostQueue.ToSend( ControllerCommand( ControllerVerb.ReplicateClose, ControllerNoun.DSet), msSend )
                 // Informed peer that Close, DSet received. 
             | ( ControllerVerb.Get, ControllerNoun.ClusterInfo ) ->
@@ -1084,14 +1070,14 @@ and [<AllowNullLiteral>]
                 let serial = msRcvd.ReadInt64()
                 let numElems = msRcvd.ReadVInt32()
                 let peerIdx = msRcvd.ReadVInt32()
-                let msSend = new MemStream( 1024 )
-                msSend.WriteString( x.Name )
-                msSend.WriteInt64( x.Version.Ticks )
-                msSend.WriteVInt32( parti )
-                msSend.WriteInt64( serial )
-                msSend.WriteVInt32( numElems )
-                msSend.WriteVInt32( peerIdx )
                 if Utils.IsNotNull x.HostQueue && x.HostQueue.CanSend then 
+                    use msSend = new MemStream( 1024 )
+                    msSend.WriteString( x.Name )
+                    msSend.WriteInt64( x.Version.Ticks )
+                    msSend.WriteVInt32( parti )
+                    msSend.WriteInt64( serial )
+                    msSend.WriteVInt32( numElems )
+                    msSend.WriteVInt32( peerIdx )
                     x.HostQueue.ToSend( ControllerCommand( ControllerVerb.Echo2Return, ControllerNoun.DSet), msSend )
             | ( ControllerVerb.Acknowledge, ControllerNoun.DSet ) ->
                 ()
@@ -1144,6 +1130,7 @@ and [<AllowNullLiteral>]
                     let useVersionName, _, provider = lst.[idx]
                     let useVersion = StringTools.VersionFromString( useVersionName )
                     let dsetOpt, blockingOn, sendStream = DSetPeer.RetrieveDSetMetadata( jobID, name, useVersion.Ticks, provider )
+                    (sendStream :> IDisposable).Dispose()
                     match dsetOpt with 
                     | Some ( s ) ->
                         let sendDSet = Option.get dsetOpt
@@ -1158,6 +1145,7 @@ and [<AllowNullLiteral>]
                 useDSet
             else
                 null
+
     static member ExceptionToClient( jobID, name, verNumber, ex ) = 
         let msSend = new MemStream( 10240 )
         msSend.WriteGuid( jobID )
@@ -1189,6 +1177,7 @@ and [<AllowNullLiteral>]
             let msg = sprintf "Error in DSetPeer.GetDSet, exception %A" ex
             ex.Data.Add( "@Daemon", msg )
             DSetPeer.ExceptionToClient( jobID, name, verNumber, ex )
+
     static member RetrieveDSetMetadata( jobID: Guid, name, verNumber, provider ) = 
         let path = DSetPeer.ConstructDSetPath( name, verNumber )
         let metaLst = 
@@ -1202,6 +1191,7 @@ and [<AllowNullLiteral>]
             DSetPeer.ReadFromMetaData( stream, null, jobID )
         else
             ( None, ClientBlockingOn.DSet, null )
+
     static member UseDSet( jobID, name, verNumber ) = 
         try 
             let storageProviderList = 
@@ -1256,6 +1246,7 @@ and [<AllowNullLiteral>]
             msSend.WriteInt64( verNumber )
             msSend.WriteException( ex )
             ( ControllerCommand( ControllerVerb.Exception, ControllerNoun.DSet ), msSend ) 
+
     /// Test for Empty Partition 
     /// Return: true for partition with 0 keys
     member x.EmptyPartition parti =
@@ -1265,6 +1256,7 @@ and [<AllowNullLiteral>]
             let maxStreamLength = Array.max x.MappingStreamLength.[parti]
             bNullStream <- maxNumElems = 0 && maxStreamLength=0L        
         bNullStream
+
     /// Read one chunk in async work format. 
     /// Return: Async<byte[]>, if return null, then the operation reads the end of stream of partition parti. 
     member x.AsyncReadChunk (jbInfo:JobInformation) parti ( pushChunkFunc: (BlobMetadata*MemStream)->unit ) = 
@@ -1329,7 +1321,8 @@ and [<AllowNullLiteral>]
                                                         let serial = ms.ReadInt64()
                                                         let numElems = ms.ReadVInt32()
                                                         let meta = BlobMetadata( parti, serial, numElems, buflen )
-                                                        pushChunkFunc( meta, ms )  
+                                                        pushChunkFunc( meta, ms )
+                                                        (ms :> IDisposable).Dispose()  
                                                     else
                                                         Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "Throw away %dB as stored SHA512 hash doesn't match" readlen ) )
                                                         nSomeError := !nSomeError + 1
@@ -1353,7 +1346,7 @@ and [<AllowNullLiteral>]
                         let msg = sprintf "Error in AsyncReadChunk, with exception %A, stack %A" e (StackTrace (0, true))
                         let bSendHost = Utils.IsNotNull x.HostQueue && x.HostQueue.CanSend 
                         if bSendHost then 
-                            let msError = new MemStream( 1024 )
+                            use msError = new MemStream( 1024 )
                             msError.WriteString( msg ) 
                             x.HostQueue.ToSend( ControllerCommand( ControllerVerb.Error, ControllerNoun.Message ), msError )
                         Logger.Log( LogLevel.Error, ((sprintf "Send Host: %A" bSendHost) + msg))
@@ -1427,7 +1420,8 @@ and [<AllowNullLiteral>]
                                                     let serial = ms.ReadInt64()
                                                     let numElems = ms.ReadVInt32()
                                                     let meta = BlobMetadata( parti, serial, numElems, buflen )
-                                                    pushChunkFunc( meta, ms )  
+                                                    pushChunkFunc( meta, ms ) 
+                                                    (ms :> IDisposable).Dispose() 
                                                 else
                                                     Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "Throw away %dB as stored SHA512 hash doesn't match" readlen ) )
                                                     nSomeError := !nSomeError + 1
@@ -1451,7 +1445,7 @@ and [<AllowNullLiteral>]
                     let msg = sprintf "Error in SyncReadChunk, with exception %A, stack %A " e (StackTrace (0, true))
                     Logger.Log( LogLevel.Error, msg )
                     if Utils.IsNotNull x.HostQueue && x.HostQueue.CanSend then 
-                        let msError = new MemStream( 1024 )
+                        use msError = new MemStream( 1024 )
                         msError.WriteString( msg ) 
                         x.HostQueue.ToSend( ControllerCommand( ControllerVerb.Error, ControllerNoun.Message ), msError )
                 null, true

--- a/src/CoreLib/GV.fs
+++ b/src/CoreLib/GV.fs
@@ -342,8 +342,9 @@ and /// Information of Within Job cluster information.
                         | _ -> 
                             Logger.Fail( sprintf "ClusterJobInfo.QueueForWriteBetweenContainer, in cluster %s:%s, unknown node type %A for peer %d to connect to" 
                                             x.LinkedCluster.Name x.LinkedCluster.VersionString ndInfo.NodeType peeri )
+                    x.LinkedCluster.PeerIndexFromEndpoint.[queue.RemoteEndPoint] <- peeri
                     queue.GetOrAddRecvProc ("ClusterParseHost", Cluster.ParseHostCommand queue peeri) |> ignore
-                    queue.OnConnect.Add( fun _ -> let ms = new MemStream(1024)
+                    queue.OnConnect.Add( fun _ -> use ms = new MemStream(1024)
                                                   ms.WriteString( x.LinkedCluster.Name )
                                                   ms.WriteInt64( x.LinkedCluster.Version.Ticks )
                                                   ms.WriteVInt32( x.CurPeerIndex )
@@ -476,16 +477,16 @@ type internal JobLifeCycle(jobID:Guid) =
             CTSSource.Dispose()
     /// EndJob has been called, the flag is mainly serve for debugging purpose. 
     /// If the jobLifeCycle object hasn't been disposed after EndJob has been called for a while, something is wrong 
-    member val EndJobMark = false with get, set
+    member val EndJobMark = ref 0 with get, set
     /// End/Cancel a particular job
     /// This function can be called multiple times concurrently, only one instance of the call will be executed. 
     /// Also, during execution, it will wait for any SingleJobActionGeneric that relies on the current job to complete before executing this action. 
     member x.EndJob() = 
         // This process is responsible for the disposing routine
-        x.EndJobMark <- true 
-        let cnt = Interlocked.Decrement( x.numJobActionsInProcess )
-        if cnt < 0 then 
-            x.DisposeJob()
+        if Interlocked.Increment( x.EndJobMark ) = 1 then 
+            let cnt = Interlocked.Decrement( x.numJobActionsInProcess )
+            if cnt < 0 then 
+                x.DisposeJob()
     override x.Finalize() =
         /// Close All Active Connection, to be called when the program gets shutdown.
         x.EndJob()
@@ -665,7 +666,7 @@ type internal SingleJobActionGeneric<'T when 'T :> JobLifeCycle and 'T : null >(
     /// Whether we have successfully hold a JobLifeCycle object and garantee that can use the object before it is being cancelled 
     let cnt = if Utils.IsNull jobLifeCycle then Int32.MinValue else Interlocked.Increment( jobLifeCycle.numJobActionsInProcess )
     let isCancellationRequested() = 
-        cnt<=0 || jobLifeCycle.EndJobMark || jobLifeCycle.IsCancellationRequested
+        cnt<=0 || !jobLifeCycle.EndJobMark>0 || jobLifeCycle.IsCancellationRequested
     let jobID = if not (isCancellationRequested()) then jobLifeCycle.JobID else Guid.Empty
     let nDisposed = ref 0 
     member x.JobID with get() = jobID
@@ -1732,7 +1733,7 @@ type internal AggregateFunction<'K>( func: 'K -> 'K -> 'K ) =
 // Prajna Serialize function
 // Used at Prajna Client
 [<AllowNullLiteral>]
-type internal GVSerialize( func: MemStream -> Object  -> MemStream ) = 
+type internal GVSerialize( func: StreamBase<byte> -> Object  -> StreamBase<byte> ) = 
     member val SerializeFunc = func with get
 
 // Prajna Serialization functions
@@ -1740,7 +1741,7 @@ type internal GVSerialize( func: MemStream -> Object  -> MemStream ) =
 [<AllowNullLiteral>]
 type internal GVSerialize<'K>( ) = 
     inherit GVSerialize( 
-        let wrapperFunc (ms:MemStream) (O1:Object) =
+        let wrapperFunc (ms:StreamBase<byte>) (O1:Object) =
             let state1 = if Utils.IsNotNull O1 then O1 :?> 'K else Unchecked.defaultof<_>
             ms.SerializeFrom( state1 )
             ms

--- a/src/CoreLib/assembly.fs
+++ b/src/CoreLib/assembly.fs
@@ -224,8 +224,7 @@ and [<AllowNullLiteral>]
     member x.ComputeHash( ) = 
         if Utils.IsNull x.Hash then 
             use ms = new MemStream() 
-            x.Pack( ms )  
-            // x.Hash <- HashByteArrayWithLength( ms.GetBufferPosLength()  )
+            x.Pack( ms )
             let (ms, pos, len) = ms.GetBufferPosLength()
             x.Hash <- ms.ComputeSHA256(int64 pos, int64 len)
             Logger.LogF( LogLevel.WildVerbose, ( fun _ ->  let fileinfo = System.IO.FileInfo( x.Location ) 

--- a/src/CoreLib/contracts.fs
+++ b/src/CoreLib/contracts.fs
@@ -173,11 +173,11 @@ type internal ContractStoreCommon() =
         let bSuccess =  Utils.IsNull !errorMsg
         if not ( Utils.IsNull queue ) && queue.CanSend then 
             if bSuccess then 
-                let msFeedback = new MemStream( 64 )
+                use msFeedback = new MemStream( 64 )
                 msFeedback.WriteGuid( reqID ) 
                 queue.ToSend( ControllerCommand( ControllerVerb.Reply, ControllerNoun.Contract), msFeedback )
             else
-                let msError = new MemStream( (!errorMsg).Length * 2 + 16)
+                use msError = new MemStream( (!errorMsg).Length * 2 + 16)
                 msError.WriteGuid( reqID ) 
                 msError.WriteString( !errorMsg ) 
                 queue.ToSend( ControllerCommand( ControllerVerb.FailedRequest, ControllerNoun.Contract), msError )
@@ -216,7 +216,7 @@ type internal ContractStoreCommon() =
                         let queue = Cluster.Connects.LookforConnectBySignature( queueSignature ) 
                         if not ( Utils.IsNull queue ) && queue.CanSend then 
                             let arr = lst.ToArray()
-                            let msReply = new MemStream() 
+                            use msReply = new MemStream() 
                             msReply.WriteGuid( reqID )
                             msReply.SerializeObjectWithTypeName( arr )
                             Logger.LogF( DeploymentSettings.TraceLevelSeqFunction, ( fun _ -> sprintf "ParseRemoteSeqFunction: Reply, Contract to send %d count of %s as reply for req %A (%dB)"
@@ -231,7 +231,7 @@ type internal ContractStoreCommon() =
                 if not ( Utils.IsNull queue ) && queue.CanSend then 
                     if lst.Count > 0 then 
                         let arr = lst.ToArray()
-                        let msReply = new MemStream() 
+                        use msReply = new MemStream() 
                         msReply.WriteGuid( reqID )
                         msReply.SerializeObjectWithTypeName( arr )
                         Logger.LogF( DeploymentSettings.TraceLevelSeqFunction, ( fun _ -> sprintf "ParseRemoteSeqFunction: Reply, Contract to send FINAL %d count of %s (+null) as reply for req %A (%dB)"
@@ -246,7 +246,7 @@ type internal ContractStoreCommon() =
                                                                                             reqID ))
                         
                     /// Signal the end of the reply 
-                    let msEnd = new MemStream() 
+                    use msEnd = new MemStream() 
                     msEnd.WriteGuid( reqID )
                     msEnd.SerializeObjectWithTypeName( null )
                     queue.ToSend( ControllerCommand( ControllerVerb.Reply, ControllerNoun.Contract), msEnd )
@@ -254,7 +254,7 @@ type internal ContractStoreCommon() =
             Logger.Log( LogLevel.MildVerbose, !errorMsg )
             let queue = Cluster.Connects.LookforConnectBySignature( queueSignature ) 
             if not ( Utils.IsNull queue ) && queue.CanSend then 
-                    let msError = new MemStream( (!errorMsg).Length * 2 + 20 )
+                    use msError = new MemStream( (!errorMsg).Length * 2 + 20 )
                     msError.WriteGuid( reqID )
                     msError.WriteString( !errorMsg ) 
                     queue.ToSend( ControllerCommand( ControllerVerb.FailedRequest, ControllerNoun.Contract), msError )
@@ -279,12 +279,12 @@ type internal ContractStoreCommon() =
         let bSuccess = Utils.IsNull !errorMsg
         if not ( Utils.IsNull queue ) && queue.CanSend then 
             if bSuccess then 
-                let msReply = new MemStream( 64 )
+                use msReply = new MemStream( 64 )
                 msReply.WriteGuid( reqID ) 
                 msReply.SerializeObjectWithTypeName( !resultRef )
                 queue.ToSend( ControllerCommand( ControllerVerb.Reply, ControllerNoun.Contract), msReply )
             else
-                let msError = new MemStream( (!errorMsg).Length * 2 + 20 )
+                use msError = new MemStream( (!errorMsg).Length * 2 + 20 )
                 msError.WriteGuid( reqID ) 
                 msError.WriteString( !errorMsg ) 
                 queue.ToSend( ControllerCommand( ControllerVerb.FailedRequest, ControllerNoun.Contract), msError )
@@ -313,7 +313,7 @@ type internal ContractStoreCommon() =
                     /// Send partial result back to server. 
                     let queue = Cluster.Connects.LookforConnectBySignature( queueSignature ) 
                     if not ( Utils.IsNull queue ) && queue.CanSend then 
-                        let msReply = new MemStream() 
+                        use msReply = new MemStream() 
                         msReply.WriteGuid( reqID )
                         msReply.SerializeObjectWithTypeName( reply.Result )
                         queue.ToSend( ControllerCommand( ControllerVerb.Reply, ControllerNoun.Contract), msReply )
@@ -325,7 +325,7 @@ type internal ContractStoreCommon() =
             Logger.Log( LogLevel.MildVerbose, !errorMsg )
         if not ( Utils.IsNull queue ) && queue.CanSend then 
             if not bSuccess then 
-                let msError = new MemStream( (!errorMsg).Length * 2 + 20)
+                use msError = new MemStream( (!errorMsg).Length * 2 + 20)
                 msError.WriteGuid( reqID )
                 msError.WriteString( !errorMsg ) 
                 queue.ToSend( ControllerCommand( ControllerVerb.FailedRequest, ControllerNoun.Contract), msError )
@@ -571,7 +571,7 @@ type internal ContractStoreAtDaemon() =
                 if Utils.IsNotNull queue && queue.CanSend then 
                     if contractInfo.IsAggregable then 
                         // Insert a null reply before error 
-                        let msNull = new MemStream( 1024 )
+                        use msNull = new MemStream( 1024 )
                         msNull.WriteGuid( reqID )
                         CustomizedSerialization.WriteNull(msNull) 
                         queue.ToSend( ControllerCommand( ControllerVerb.Reply, ControllerNoun.Contract ), msNull )
@@ -628,7 +628,7 @@ type internal ContractStoreAtDaemon() =
                                                                            ))
                     let queue = Cluster.Connects.LookforConnectBySignature( epSignature )
                     if not (Utils.IsNull queue) && queue.CanSend then 
-                        let msContract = new MemStream( 1024 )
+                        use msContract = new MemStream( 1024 )
                         msContract.WriteStringV( name )
                         queue.ToSend( ControllerCommand( ControllerVerb.Close, ControllerNoun.Contract ), msContract )
                     x.ImportCollections.TryRemove( pair0.Key ) |> ignore 
@@ -648,7 +648,7 @@ type internal ContractStoreAtDaemon() =
                     Logger.Log( LogLevel.ExtremeVerbose, errMsg )
                     let queue = Cluster.Connects.LookforConnectBySignature( replyToSignature )
                     if Utils.IsNotNull queue && queue.CanSend then 
-                        let msError = new MemStream( errMsg.Length * 2 + 20) 
+                        use msError = new MemStream( errMsg.Length * 2 + 20) 
                         msError.WriteGuid( reqID ) 
                         msError.WriteString( errMsg ) 
                         queue.ToSend( ControllerCommand( ControllerVerb.FailedRequest, ControllerNoun.Contract ), msError )
@@ -709,7 +709,7 @@ type internal ContractStoreAtDaemon() =
                         Logger.Log( LogLevel.MildVerbose, errMsg )
                         let queue = Cluster.Connects.LookforConnectBySignature( replyToSignature )
                         if Utils.IsNotNull queue && queue.CanSend then 
-                            let msError = new MemStream( errMsg.Length * 2 + 20) 
+                            use msError = new MemStream( errMsg.Length * 2 + 20) 
                             msError.WriteGuid( reqID ) 
                             msError.WriteString( errMsg ) 
                             queue.ToSend( ControllerCommand( ControllerVerb.FailedRequest, ControllerNoun.Contract ), msError )
@@ -793,7 +793,7 @@ type internal ContractResolver( name ) =
             if Utils.IsNull reqHolder then 
                 // This happens for Action, in which we do not track incoming reply
                 ContractResolver.OutgoingCollections.TryRemove( reqID ) |> ignore     
-            let msRequest = new MemStream( )
+            use msRequest = new MemStream( )
             msRequest.WriteStringV( name )
             msRequest.WriteGuid( reqID ) 
             msRequest.SerializeObjectWithTypeName( inp )
@@ -1004,10 +1004,9 @@ type ContractServersInfo() =
     /// Add a cluster 
     member x.AddCluster( cl: Cluster ) = 
         if Utils.IsNotNull cl then 
-            let ms = new MemStream()
+            use ms = new MemStream()
             cl.Pack( ms )
             let oneCluster = ContractServerType.ServerCluster( cl.Name, cl.Version.Ticks, ms.GetBuffer() )
-            ms.DecRef()
             x.ServerCollection.Enqueue( oneCluster )
             x.NewID()
 //    /// Get all clusters in the serversinfo
@@ -1313,7 +1312,7 @@ type internal ContractStoreAtProgram() =
     /// </summary> 
     member x.RegisterContractToServers (serversInfo) ( name, info, bReload, parseFunc: int64*StreamBase<byte> -> unit ) = 
         let mutable bRegisterSuccessful = false
-        let msInfo = ContractInfo.PackWithName( name, info, bReload )
+        use msInfo = ContractInfo.PackWithName( name, info, bReload )
         x.Collections.Item( name ) <- parseFunc
         let allqueues = ContractServerQueues.GetNetworkQueues( serversInfo ) 
         let store = x.RegisteredContract.GetOrAdd( name, fun _ -> ContractRequest() )
@@ -1330,7 +1329,7 @@ type internal ContractStoreAtProgram() =
     member x.RegisterContractToDaemon  = 
         x.RegisterContractToServers null  
     member x.LookforContractAtServers ( registerFunc:int64 -> unit) (unregisterFunc:string->int64->unit) (constructReqFunc) (serversInfo:ContractServersInfo) ( name, info: ContractInfo) = 
-        let msLookfor = new MemStream( )
+        use msLookfor = new MemStream()
         msLookfor.WriteStringV( name ) 
         let addFunc name = 
             let oneResolver = 
@@ -1521,7 +1520,7 @@ type internal ContractStoreAtProgram() =
                     Logger.Log( LogLevel.MildVerbose, errMsg )
                     let queue = Cluster.Connects.LookforConnectBySignature( queueSignature ) 
                     if Utils.IsNotNull queue && queue.CanSend then 
-                        let msError = new MemStream( errMsg.Length * 2 + 20 )
+                        use msError = new MemStream( errMsg.Length * 2 + 20 )
                         msError.WriteGuid( reqID ) 
                         msError.WriteString( errMsg ) 
                         queue.ToSend( ControllerCommand( ControllerVerb.FailedRequest, ControllerNoun.Contract), msError )
@@ -1533,7 +1532,7 @@ type internal ContractStoreAtProgram() =
                 Logger.Log( LogLevel.MildVerbose, errMsg )
                 let queue = Cluster.Connects.LookforConnectBySignature( queueSignature ) 
                 if Utils.IsNotNull queue && queue.CanSend then 
-                    let msError = new MemStream( errMsg.Length * 2 + 20 )
+                    use msError = new MemStream( errMsg.Length * 2 + 20 )
                     msError.WriteGuid( reqID ) 
                     msError.WriteString( errMsg ) 
                     queue.ToSend( ControllerCommand( ControllerVerb.FailedRequest, ControllerNoun.Contract), msError )

--- a/src/CoreLib/dependency.fs
+++ b/src/CoreLib/dependency.fs
@@ -259,7 +259,6 @@ type JobDependencies() =
             ms.WriteBytes( dep.Hash ) |> ignore 
         let (buf, pos, cnt) = ms.GetBufferPosLength()
         x.Hash <- ms.ComputeSHA256(int64 pos, int64 cnt)
-        ms.DecRef()
         x.Hash
 
     /// Get Hash version string

--- a/src/CoreLib/function.fs
+++ b/src/CoreLib/function.fs
@@ -266,19 +266,11 @@ type internal MetaFunction<'U>() as x =
             Logger.LogF( LogLevel.ExtremeVerbose, ( fun _ -> sprintf "EncodeFunc, type %A input metadata %s output metadata %s" (elemArray.GetType()) (meta.ToString()) (encMeta.ToString()) ))
             if encMeta.NumElems<>elemArray.Length then 
                 let msg = sprintf "Error in MetaFunction<'U>.EncodeFunc, the length of key array doesn't match that of numElems, %s (actual %d key-values)" (MetaFunction.MetaString(meta)) elemArray.Length
-                Logger.Log( LogLevel.Warning, msg )            
-           // let ms = new MemStream() :> StreamBase<byte>
+                Logger.Log( LogLevel.Warning, msg )
             let ms = new MemoryStreamB() :> StreamBase<byte>
             ms.Info <- sprintf "EncodeFunc:"
             let orgpos = ms.Position // Position 0, 
             ms.SerializeFrom( elemArray )
-//            if Utils.IsNotNull valueArray then 
-//                if numElems<>valueArray.Length then 
-//                    let msg = sprintf "Error in MetaFunction<'K, 'V>.encodeFunc, the length of value array doesn't match that of numElems, part:%d, serial:%d, numElems:%d (%d keys, %d values)" parti serial numElems keyArray.Length valueArray.Length
-//                    Logger.Log(LogLevel.Error, msg)
-//                    failwith msg
-//            else
-//                ms.Serialize( null )
             // Set position to be read by the DecodeFunc
             ms.Seek( orgpos, SeekOrigin.Begin ) |> ignore
             ( encMeta, ms )
@@ -288,7 +280,6 @@ type internal MetaFunction<'U>() as x =
             Logger.LogF( LogLevel.WildVerbose, ( fun _ -> sprintf "EncodeFunc, input metadata %s output metadata %s" (meta.ToString()) (encMeta.ToString()) ))
             // Signal the end of stream. 
             ( encMeta, null )
-
 
 /// Mapping function wrapper: helps to deserialize and serialize Memstreams
 /// Generic, allows mapping from DSet<'U> -> DSet<'U1>
@@ -1624,7 +1615,7 @@ type internal Function () =
                 null
             | _ ->
                 let bytearray = ms.ReadBytesWLen()
-                use msFunc = new MemStream( bytearray, 0, bytearray.Length, false, true  )
+                use msFunc = new MemStream( bytearray, 0, bytearray.Length, false, true )
                 if DeploymentSettings.LoadCustomAssebly && bUnpackFunc then 
                     try
                         let o = msFunc.Deserialize() 
@@ -1638,8 +1629,6 @@ type internal Function () =
                 else
                     // Don't unpack function
                     null
-//                let fmt = Formatters.Binary.BinaryFormatter()
-//                fmt.Deserialize( ms )
         Function( FunctionType = functionType, 
             TransformType = transformType, 
             ParamTypes = paramTypes, 

--- a/src/CoreLib/listener.fs
+++ b/src/CoreLib/listener.fs
@@ -201,7 +201,7 @@ type JobListener() =
                         /// Wait a long time and the job still doesn't start
                         let msg1 = sprintf "Rcvd from %A msg of InfoContainer, Job (%dB) claiming from Cluster %s:%s of peer %d, wait for %f seconds, but can't resolve Cluser" (queuePeer.RemoteEndPoint) ( ms.Length - ms.Position ) name (VersionToString(DateTime(verNumber))) peerIndex elapse
                         Logger.Log( LogLevel.Error, (msg1))
-                        let msError = new MemStream( 1024 )
+                        use msError = new MemStream( 1024 )
                         msError.WriteString( msg1 ) 
                         queuePeer.ToSend( ControllerCommand( ControllerVerb.Error, ControllerNoun.Message ), msError )
                     elif queuePeer.Shutdown then 
@@ -264,7 +264,7 @@ type JobListener() =
                                     let msg1 = sprintf "Rcvd from %A msg of %A (%dB) for DStream %s:%s, wait for %f seconds, but " (queuePeer.RemoteEndPoint) command ( ms.Length - ms.Position ) name (VersionToString(DateTime(verNumber))) elapse
                                     let msg2 = !reasonBlocked
                                     Logger.Log( LogLevel.Error, (msg1+msg2))
-                                    let msError = new MemStream( 1024 )
+                                    use msError = new MemStream( 1024 )
                                     msError.WriteString( msg1 + msg2 ) 
                                     queuePeer.ToSend( ControllerCommand( ControllerVerb.Error, ControllerNoun.Message ), msError )
                                 elif queuePeer.Shutdown then 

--- a/src/ServiceLib/BasicService/monitornetwork.fs
+++ b/src/ServiceLib/BasicService/monitornetwork.fs
@@ -133,12 +133,11 @@ type MonitorNetworkInstance< 'StartParamType
         let mutable ticksCycleStart = (PerfADateTime.UtcNowTicks())
         let mutable cntCur = 0 
         /// Generate a 102400B stream that to be written out. 
-        let msStream = new MemStream( x.EchoStreamLength )
+        use msStream = new MemStream( x.EchoStreamLength )
         let rnd = System.Random(0)
         let byt = Array.zeroCreate( x.EchoStreamLength )
         rnd.NextBytes( byt )
         msStream.Write( byt, 0, x.EchoStreamLength )
-
 
         while not (x.EvTerminated.WaitOne(0)) do 
             let ticksCycleStart = (PerfDateTime.UtcNowTicks())

--- a/src/ServiceLib/Gateway/frontend.fs
+++ b/src/ServiceLib/Gateway/frontend.fs
@@ -596,7 +596,7 @@ type FrontEndInstance< 'StartParamType
             if bExist then 
                 for cmd, ms in x.InitialMessage do 
                     // Wrap initial message with health information & end marker
-                    let msSend = new MemStream( int ms.Length + 128 ) 
+                    use msSend = new MemStream( int ms.Length + 128 ) 
                     health.WriteHeader( msSend ) 
                     let (ms, pos, len) = ms.GetBufferPosLength()
                     msSend.AppendNoCopy(ms, int64 pos, int64 len)
@@ -616,7 +616,7 @@ type FrontEndInstance< 'StartParamType
                     if not (Utils.IsNull queue ) && queue.CanSend then 
                         // send echo message 
                         let t1 = (PerfADateTime.UtcNowTicks())
-                        let msEcho = new MemStream( 128 ) 
+                        use msEcho = new MemStream( 128 ) 
                         health.WriteHeader( msEcho ) 
                         health.WriteEndMark( msEcho ) 
                         queue.ToSend( ControllerCommand(ControllerVerb.Echo, ControllerNoun.QueryReply ), msEcho )
@@ -668,7 +668,7 @@ type FrontEndInstance< 'StartParamType
                     let collection = OwnershipTracking.Current.RemoteCollection.GetOrAdd( remoteSignature, fun _ -> ConcurrentDictionary<_,_>() )
                     guids |> Array.iter ( fun guid -> collection.Item( guid ) <- null )
                     let items = BufferCache.Current.FindMissingGuids( guids ) 
-                    let msSend = new MemStream( )
+                    use msSend = new MemStream( )
                     health.WriteHeader( msSend ) 
                     BufferCache.PackGuid( items, msSend )
                     health.WriteEndMark( msSend ) 
@@ -749,7 +749,7 @@ type FrontEndInstance< 'StartParamType
         let queue = Cluster.Connects.LookforConnectBySignature( remoteSignature ) 
         let bExist, health = x.BackEndHealth.TryGetValue( remoteSignature ) 
         if bExist && Utils.IsNotNull queue then 
-            let msSend = new MemStream( )
+            use msSend = new MemStream( )
             health.WriteHeader( msSend ) 
             BufferCache.PackGuid( [| id |], msSend )
             health.WriteEndMark( msSend ) 
@@ -970,7 +970,7 @@ type FrontEndInstance< 'StartParamType
     /// Return : true is request is sent
     member internal x.SendRequest( reqID, reqHolder, tuple ) = 
         let queue, health, serviceInstanceBasic = tuple
-        let msRequest = new MemStream( ) 
+        use msRequest = new MemStream( ) 
         // Count the request as being sent 
         health.RegisterRequest() 
         health.WriteHeader( msRequest ) 

--- a/src/ServiceLib/KVStore/KVSotre.fs
+++ b/src/ServiceLib/KVStore/KVSotre.fs
@@ -210,7 +210,7 @@ type internal KVService<'K,'V >() =
         let filename = x.Param.GetKVStoreName()
         if File.Exists( filename ) then 
             let byt = FileTools.ReadBytesFromFile filename
-            let ms = new MemStream( byt, 0, byt.Length, false, true )
+            use ms = new MemStream( byt, 0, byt.Length, false, true )
             let cnt = ms.ReadInt32()
             for i = 0 to cnt - 1 do 
                 let key = ms.DeserializeObjectWithTypeName() :?> 'K

--- a/src/ServiceLib/ServiceEndpoint/backend.fs
+++ b/src/ServiceLib/ServiceEndpoint/backend.fs
@@ -510,7 +510,7 @@ type BackEndInstance< 'StartParamType
                 for cmd, ms in x.InitialMessage do 
                     // Wrap initial message with health information & end marker
                     let t1 = (PerfADateTime.UtcNowTicks())
-                    let msSend = new MemStream( int ms.Length + 128 ) 
+                    use msSend = new MemStream( int ms.Length + 128 ) 
                     health.WriteHeader( msSend ) 
                     let buf, pos, length = ms.GetBufferPosLength()
                     msSend.Append(buf, int64 pos, int64 length)
@@ -580,7 +580,7 @@ type BackEndInstance< 'StartParamType
                 | ControllerVerb.Read, ControllerNoun.Buffer -> 
                     let guids = BufferCache.UnPackGuid( ms ) 
                     let items = BufferCache.Current.FindCacheableBufferByGuid( guids ) 
-                    let msSend = new MemStream( )
+                    use msSend = new MemStream( )
                     health.WriteHeader( msSend ) 
                     BufferCache.PackCacheableBuffers( items, msSend )
                     health.WriteEndMark( msSend ) 
@@ -601,7 +601,7 @@ type BackEndInstance< 'StartParamType
                     x.ProcessRequest( queue, health, reqID, serviceID, requestObject )
                 | ControllerVerb.Echo, ControllerNoun.QueryReply ->
                     let t1 = (PerfDateTime.UtcNowTicks())
-                    let msSend = new MemStream( 128 )
+                    use msSend = new MemStream( 128 )
                     health.WriteHeader( msSend ) 
                     health.WriteEndMark( msSend ) 
                     queue.ToSend( ControllerCommand(ControllerVerb.EchoReturn, ControllerNoun.QueryReply ), msSend )
@@ -645,7 +645,7 @@ type BackEndInstance< 'StartParamType
             x.PrimaryQueue.Enqueue( serviceID ) 
             x.EvPrimaryQueue.Set() |> ignore 
         else
-            let msError = new MemStream( 1024 ) 
+            use msError = new MemStream( 1024 ) 
             health.WriteHeader( msError ) 
             msError.WriteBytes( serviceID.ToByteArray() )
             health.WriteEndMark( msError ) 
@@ -799,7 +799,7 @@ type BackEndInstance< 'StartParamType
         if bHealth && not (Utils.IsNull queue) then 
             let ticksCur = (PerfADateTime.UtcNowTicks())
             let elapse = int( ( ticksCur - ticks )/TimeSpan.TicksPerMillisecond ) 
-            let msTimeOut = new MemStream( 1024 ) 
+            use msTimeOut = new MemStream( 1024 ) 
             health.WriteHeader( msTimeOut ) 
             msTimeOut.WriteBytes( reqID.ToByteArray() )
             msTimeOut.WriteInt32( elapse ) // Timeout after (ms) 
@@ -819,7 +819,7 @@ type BackEndInstance< 'StartParamType
             let qPerf = SingleQueryPerformance( InQueue = timeInQueueMS, InProcessing = timeInProcessingMS, 
                                                 NumSlotsAvailable = numSlotsAvailable, 
                                                 NumItemsInQueue = numItems )
-            let msReply = new MemStream( ) 
+            use msReply = new MemStream( ) 
             health.WriteHeader( msReply )         
             msReply.WriteBytes( reqID.ToByteArray() ) 
             SingleQueryPerformance.Pack( qPerf, msReply )
@@ -835,7 +835,7 @@ type BackEndInstance< 'StartParamType
         let queue = Cluster.Connects.LookforConnectBySignature( remoteSignature ) 
         let bHealth, health = x.FrontEndHealth.TryGetValue( remoteSignature )
         if bHealth && not (Utils.IsNull queue) then 
-            let msReply = new MemStream( ) 
+            use msReply = new MemStream( ) 
             health.WriteHeader( msReply )         
             msReply.WriteBytes( reqID.ToByteArray() ) 
             msReply.WriteString( msg ) 

--- a/src/tools/tools/Tools.fsproj
+++ b/src/tools/tools/Tools.fsproj
@@ -51,7 +51,6 @@
     <Compile Include="serialize.fs" />
     <Compile Include="customserialize.fs" />
     <Compile Include="ArgumentParser.fs" />
-    <Compile Include="ReflectionTools.fs" />
     <Compile Include="HttpBuilder.fs" />
     <Compile Include="dns.fs" />
     <Compile Include="basenetwork.fs" />

--- a/src/tools/tools/customserialize.fs
+++ b/src/tools/tools/customserialize.fs
@@ -424,7 +424,7 @@ type StreamBaseExtension =
                         x.WriteInt32(int32 arr.[i].Length)
                     for i=0 to arr.Length-1 do
                         x.AppendNoCopy(arr.[i], 0L, arr.[i].Length)
-                        arr.[i].DecRef()
+                        (arr.[i] :> IDisposable).Dispose()
                 | _ ->
                     x.WriteBytes( GenericSerialization.DefaultFormatterGuid.ToByteArray() )
                     let fmt = GenericSerialization.GetDefaultFormatter()

--- a/src/tools/tools/genericnetwork.fs
+++ b/src/tools/tools/genericnetwork.fs
@@ -34,9 +34,8 @@ type [<AllowNullLiteral>] RefCntBufSA() =
 
     override x.Alloc(size : int) =
         base.Alloc(size)
-        let buf = x.GetBuffer()
         x.SA <- new SocketAsyncEventArgs()
-        x.SA.SetBuffer(buf, 0, size)
+        x.SA.SetBuffer(x.Buffer, 0, size)
 
     member val SA : SocketAsyncEventArgs = null with get, set
 
@@ -310,7 +309,7 @@ and [<AllowNullLiteral>] GenericConn() as x =
             else
                 let (x, xERecvSA) = e.UserToken :?> GenericConn*RBufPart<byte>
                 xERecvSA.Release()
-                let (event, sa) = RBufPart<byte>.GetFromPool("RecvSA", x.Net.BufStackRecv, fun _ -> new RBufPart<byte>(false) :> SafeRefCnt<RefCntBuf<byte>>)
+                let (event, sa) = RBufPart<byte>.GetFromPool("RecvSA", x.Net.BufStackRecv, fun _ -> new RBufPart<byte>() :> SafeRefCnt<RefCntBuf<byte>>)
                 let xERecvSA = sa :?> RBufPart<byte>
                 let saE = sa.Elem :?> RefCntBufSA
                 saE.SA.UserToken <- (x, xERecvSA)
@@ -336,7 +335,7 @@ and [<AllowNullLiteral>] GenericConn() as x =
                     e.SetBuffer(Array.zeroCreate<byte>(256000), 0, 256000)
                     NetUtils.RecvOrClose(x, GenericConn.SimpleFinishRecv, e)
                 else
-                    let (event, sa) = RBufPart<byte>.GetFromPool("RecvSA", x.Net.BufStackRecv, fun _ -> new RBufPart<byte>(false) :> SafeRefCnt<RefCntBuf<byte>>)
+                    let (event, sa) = RBufPart<byte>.GetFromPool("RecvSA", x.Net.BufStackRecv, fun _ -> new RBufPart<byte>() :> SafeRefCnt<RefCntBuf<byte>>)
                     let xERecvSA = sa :?> RBufPart<byte>
                     let saE = sa.Elem :?> RefCntBufSA
                     saE.SA.UserToken <- (x, xERecvSA)
@@ -426,7 +425,7 @@ and [<AllowNullLiteral>] GenericConn() as x =
     // Recv not through threadpool
     member private x.NextReceiveOne() =
         eRecvNetwork <- null
-        let (event, saRet) = RBufPart<byte>.GetFromPool("RecvSA", x.Net.BufStackRecv, fun _ -> new RBufPart<byte>(false) :> SafeRefCnt<RefCntBuf<byte>>)
+        let (event, saRet) = RBufPart<byte>.GetFromPool("RecvSA", x.Net.BufStackRecv, fun _ -> new RBufPart<byte>() :> SafeRefCnt<RefCntBuf<byte>>)
         if (Utils.IsNull event) then
             eRecvSA <- saRet :?> RBufPart<byte>
             eRecvNetwork <- saRet.Elem :?> RefCntBufSA
@@ -590,7 +589,7 @@ and [<AllowNullLiteral>] GenericConn() as x =
             (false, event)
 
     member private x.GetNextSendProcess() : ManualResetEvent =
-        let (event, eSendSA) = RBufPart<byte>.GetFromPool("SendSA", x.Net.BufStackSend, fun _ -> new RBufPart<byte>(false) :> SafeRefCnt<RefCntBuf<byte>>)
+        let (event, eSendSA) = RBufPart<byte>.GetFromPool("SendSA", x.Net.BufStackSend, fun _ -> new RBufPart<byte>() :> SafeRefCnt<RefCntBuf<byte>>)
         if (Utils.IsNull event) then
             eSendProcess <- eSendSA :?> RBufPart<byte>
             eSendNetwork <- eSendProcess.Elem :?> RefCntBufSA
@@ -628,7 +627,7 @@ and [<AllowNullLiteral>] GenericConn() as x =
         while (not bDone && Utils.IsNull event) do
             if (null = eSendProcess) then
                 if (x.Net.BufStackSendComp.Q.IsEmpty) then
-                    let (eventRet, eSendSA) = RBufPart<byte>.GetFromPool("SendSA", x.Net.BufStackSend, fun _ -> new RBufPart<byte>(false) :> SafeRefCnt<RefCntBuf<byte>>)
+                    let (eventRet, eSendSA) = RBufPart<byte>.GetFromPool("SendSA", x.Net.BufStackSend, fun _ -> new RBufPart<byte>() :> SafeRefCnt<RefCntBuf<byte>>)
                     event <- eventRet
                     if (Utils.IsNull event) then
                         eSendProcess <- eSendSA :?> RBufPart<byte>

--- a/src/tools/tools/hash.fs
+++ b/src/tools/tools/hash.fs
@@ -6,7 +6,7 @@ open System
 open System.Runtime.InteropServices
 open System.Security.Cryptography
 
-open FSharp.NativeInterop
+open Microsoft.FSharp.NativeInterop
 
 module Hash =
 

--- a/tests/tools/tools/mem.fs
+++ b/tests/tools/tools/mem.fs
@@ -12,7 +12,7 @@ module MemStreamTests =
 
     [<Test(Description = "Test constructors")>]
     let testConstructors() =
-        BufferListStream<byte>.InitSharedPool()
+        MemoryStreamB.InitSharedPool()
         
         use s1 = new MemStream()
         Assert.AreEqual(0, s1.Length)        


### PR DESCRIPTION
Change to always using MemoryStreamB, although StreamBaseByte can once again be used now.  Always use replication for memory stream as memory stream now implements IDisposable.  Standard usage is following:

use ms = new MemStream(...) // allocate a new MemStream
use ms = Function(...) // if Function returns a MemStream

If function returns MemStream then use following to create MemStream to return (caller of function will then use: "use ms = Function(...)":

let ms = new MemStream(...)

If MemStream is passed to a function, then if function needs MemStream after it returns, it must replicate and keep a copy, for example:

use ms = new MemStream(...)
ms.Write(...)
queue.ToSend(cmd, ms)

Now, since queue.ToSend actually enqueues the memstream and needs to save it, it internally will create a replica.

MemoryStreamB replication is also now faster as both the buffers are RefCnt as well as the list of buffers is RefCnt, so replication does not need to now create a new List.  It simply adds a refcnt to original list.  As this is all internal, the user of MemoryStreamB does not need to take care of anything.
