### PR TITLE
Fix one bug and modify code in Component

### DIFF
--- a/src/CoreLib/GV.fs
+++ b/src/CoreLib/GV.fs
@@ -1551,7 +1551,9 @@ and [<AllowNullLiteral>]
                 for pi = 0 to func.Length - 1 do
                     let funci = func.[pi]
                         // Only one set of threads will be launched. 
-                    x.ThreadPool.EnqueueRepeatableFunction funci (jobAction.CTS) ( parti * func.Length + pi ) ( fun _ -> nameFunc(pi))
+                    //x.ThreadPool.EnqueueRepeatableFunction funci (jobAction.CTS) ( parti * func.Length + pi ) ( fun _ -> nameFunc(pi))
+                    Component<_>.AddWorkItem funci (x.ThreadPool) (jobAction.CTS) ( parti * func.Length + pi ) ( fun _ -> nameFunc(pi)) |> ignore
+                Component<_>.ExecTP x.ThreadPool
                 x.ThreadPool.TryExecute()
         )
     member internal x.FreeBaseResource( jbInfo : JobInformation ) = 


### PR DESCRIPTION
1. Fix bug in deallocation of jobMetadataStream - potential race condition causes two calls to dispose, which
   can cuase NullReferenceException ins ome cases.
2. Add some hooks so that differing ThreadPool implementations may be easily tried.
3. Keep direct reference to bufList in BufferListStream
