### PR TITLE
Fixes for ContainerAppDomainInfo and serialization perf regression, and new PrajnaFormatter schema

### DIFF
--- a/samples/examples/FSharpExamples/NaiveBayes.fs
+++ b/samples/examples/FSharpExamples/NaiveBayes.fs
@@ -146,10 +146,10 @@ type NaiveBayes() =
 
     let setGenericSerializer (newFormatterGuid: Guid) (cluster: Cluster) = 
         printf "Switching formatter... "
-        GenericSerialization.DefaultFormatterGuid <- newFormatterGuid
         DSet<unit>(Name = "foo", Cluster = cluster)
         |> DSet.distribute (Array.zeroCreate cluster.NumNodes : unit[])
         |> DSet.iter (fun _ -> GenericSerialization.DefaultFormatterGuid <- newFormatterGuid)
+        GenericSerialization.DefaultFormatterGuid <- newFormatterGuid
         printfn "done."
 
     let run (cluster: Cluster) = 
@@ -255,7 +255,7 @@ type NaiveBayes() =
  
 //        let stream = new MemoryStream()
         use stream = new MemStream()
-        let serializer = GenericSerialization.GetFormatter GenericSerialization.PrajnaFormatterGuid
+        let serializer = GenericSerialization.GetFormatter(GenericSerialization.PrajnaFormatterGuid, null)
         sw.Restart()
 //        stream.SerializeFrom seqCounts
         serializer.Serialize(stream, seqCounts)

--- a/src/CoreLib/task.fs
+++ b/src/CoreLib/task.fs
@@ -391,7 +391,10 @@ and [<AllowNullLiteral>]
                                 //    casting a functor that extends FSharpFunc (in one DLL) to FSharFunc (in the other DLL) fail. So in Linux, we need to link assemblies, so Mono
                                 //    does not look for FSharp.Core from GAC but from job directory.
                                 ta.LinkAllAssemblies( x.JobDirectory ) 
-                            let param = ContainerAppDomainInfo( Name = x.SignatureName, Version = x.SignatureVersion, Ticks = executeTicks, JobPort = nodeInfo.ListeningPort, JobDir = x.JobDirectory, JobEnvVars = x.JobEnvVars  )
+                            let param = 
+                                ContainerAppDomainInfo( Name = x.SignatureName, Version = x.SignatureVersion, Ticks = executeTicks, JobPort = nodeInfo.ListeningPort,
+                                    JobDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), 
+                                    JobEnvVars = x.JobEnvVars  )
                             x.AppDomainInfo <- param
                             x.Thread <- ThreadTracking.StartThreadForFunction ( fun _ -> sprintf "Launch remote container as AppDomain, port %d" nodeInfo.ListeningPort) ( fun _ -> ContainerAppDomainInfo.StartProgram param )
                             x.State <- TaskState.InExecution


### PR DESCRIPTION
This pull request has 3 independent commits that I'd like to keep, since they address different issues.
1) Only today I noticed a major perf regression on closure serialization. A simple test serializaing a closure carrying a few megabytes shows a > 3x difference.
2) AppDomain cluster was broken if using external assemblies. Somehow it was resolving user assemblies, but if those refer to others, that was not getting loaded.
3) Adding SchemaPrajnaFormatterHelper per Jin's request, in case we send more than a few kilobytes to a distributed function.
