### PR TITLE
Alternative implementation of ThreadPoolWait.

### DIFF
--- a/src/CoreLib/task.fs
+++ b/src/CoreLib/task.fs
@@ -866,7 +866,7 @@ and [<AllowNullLiteral; Serializable>]
         x.TraverseAllObjects TraverseUpstream (List<_>(DeploymentSettings.NumObjectsPerJob)) dset (x.ResetAll jbInfo)
         x.TraverseAllObjectsWDirection TraverseUpstream (List<_>(DeploymentSettings.NumObjectsPerJob)) dset (x.PreBeginSync jbInfo)
 
-    member x.CloseAllSync jbInfo ( dset: DSet ) = 
+    member x.CloseAllSync jobAction jbInfo ( dset: DSet ) = 
         let t1 = (PerfDateTime.UtcNow())       
         Logger.LogF( x.JobID, LogLevel.MildVerbose, ( fun _ -> sprintf "start PreClose %A %s:%s ........" dset.ParamType dset.Name dset.VersionString ) )
         if Utils.IsNull x.WaitForCloseAllStreamsHandleCollection then 
@@ -1228,7 +1228,7 @@ and [<AllowNullLiteral; Serializable>]
                             jobAction.EncounterExceptionAtContainer( ex, "___ SyncJobExecutionAsSeparateApp (loop on WaitForAll) ___" )
                         // JinL: note some of the write task may not finish at this moment. 
                         if x.IsJobInitializer(dset) && not (!bExistPriorTasks) then 
-                            x.CloseAllSync jbInfo dset
+                            x.CloseAllSync jobAction jbInfo dset
                             Logger.LogF( x.JobID, LogLevel.MildVerbose, ( fun _ -> sprintf "%s Task %s:%s, DSet %s:%s is completed in %f ms........." taskName x.Name x.VersionString dset.Name dset.VersionString ((PerfDateTime.UtcNow()).Subtract( x.JobStartTime ).TotalMilliseconds) ))
                             Logger.LogF( x.JobID, LogLevel.MildVerbose, ( fun _ -> "=======================================================================================================================================" ))
                             x.JobReady.Reset() |> ignore


### PR DESCRIPTION
ThreadPoolWait implement functionality of ThreadPoolWait .RegisterWaitForSingleObject, with three capability:
1. To remove a particular wait handle and cancel its operation
2. To show all wait handles queued in the system,
   and 3. To show long continuation (not normal).

The old implementation uses a customized threadpool. The new implementation uses ThreadPoolWait.RegisterWaitForSingleObject.

One potential performance issue is that:

ThreadPoolWait.MaxSpinMs = 200 ms.

This is the time between the callback is called, and the registeredWaitHandle is put into the system. I found that if I set

ThreadPoolWait.MaxSpinMs = 50 ms.

Sometime, the system will show it is unable to grab the registeredWaitHandle in 50ms. I can't reason why it takes so long for the
ThreadPoolWait.RegisterWaitForSingleObject to get back. In slower system, we may need to use a even larger wait.
