### PR TITLE
Fix race condition causing NullReferenceException when ReleaseAllItem…

### DIFF
--- a/samples/SortBenchmark/qsort/qsort.cpp
+++ b/samples/SortBenchmark/qsort/qsort.cpp
@@ -4,7 +4,7 @@
 #include <stdlib.h>     
 #include <string.h>
 #include <algorithm>
-#include <cstdlib>
+//#include <cstdlib>
 #include "sort.h"
 
 #include <vector>
@@ -13,13 +13,17 @@
 static int d = 100;
 static int hashBytes = 2;
 
-int compare(const void * a, const void * b)
+int compare(void *context, const void * a, const void * b)
 {
 	return memcmp(a, b, d);
 }
-bool compareb(const void * a, const void * b)
+bool compareb(void *context, const void * a, const void * b)
 {
 	return memcmp(a, b, d) < 0;
+}
+bool comparec(const void * a, const void * b)
+{
+    return memcmp(a, b, d) < 0;
 }
 
 #define swapcode(TYPE, parmi, parmj, n) { 		\
@@ -37,7 +41,7 @@ extern "C" __declspec(dllexport)
 void stdquicksort(void* buf, int len, int dim)
 {
 	dim = d;
-	qsort_s(buf, len, dim, compare, null);
+	qsort_s(buf, len, dim, compare, 0);
 }
 
 
@@ -198,7 +202,7 @@ void stdsort(void* buf, int len, int dim)
 		p = p + dim;
 	}
 
-	std::sort(pointer.begin(), pointer.end(), compareb);
+	std::sort(pointer.begin(), pointer.end(), comparec);
 
 	char* tbuf = new char[len*dim];
 

--- a/src/CoreLib/job.fs
+++ b/src/CoreLib/job.fs
@@ -2613,6 +2613,8 @@ and
                 else
                     Threading.Thread.Sleep(5)
             Logger.LogF( x.JobID, LogLevel.MildVerbose, ( fun _ -> sprintf "Job %s:%s of task %s is ready to execute" x.Name x.VersionString x.SignatureName ))
+            let bAllPeerConfirmed = bAllPeerConfirmed
+            let numConfirmedStart = numConfirmedStart
             Logger.LogF( x.JobID, LogLevel.WildVerbose, ( fun _ -> sprintf "bAllSynced = %b, bAllPeerConfirmed = %b, numConfirmedStart = %i" bAllSynced bAllPeerConfirmed numConfirmedStart))
             // bAllSynced is always true, so should be bAllPeerConfirmed
             bAllSynced && bAllPeerConfirmed && numConfirmedStart>0

--- a/src/tools/tools/process.fs
+++ b/src/tools/tools/process.fs
@@ -1656,7 +1656,8 @@ and [<AllowNullLiteral>]
                     let numBlockedThreads = Volatile.Read( x.NumberOfBlockedThreads )
                     let numTasks = Volatile.Read( x.NumberOfTasks )
                     let numWaitedTasks = Volatile.Read(x.NumberOfWaitedTasks)
-                    Logger.LogF(LogLevel.WildVerbose, fun _ -> sprintf "TryExecute: pool = %s, nThreads = %i, numBlockedThreads = %i, numTasks = %i, numWaitedTasks = %i" x.ThreadPoolName numThreads numBlockedThreads numTasks numWaitedTasks)
+                    let curNumThreads = numThreads
+                    Logger.LogF(LogLevel.WildVerbose, fun _ -> sprintf "TryExecute: pool = %s, nThreads = %i, numBlockedThreads = %i, numTasks = %i, numWaitedTasks = %i" x.ThreadPoolName curNumThreads numBlockedThreads numTasks numWaitedTasks)
                     if not (numThreads - numBlockedThreads < ThreadPoolWithWaitHandles<'K>.MinActiveThreads && numThreads < numTasks - numWaitedTasks) then
                         exitsLoop <- true
                     else 
@@ -1676,7 +1677,8 @@ and [<AllowNullLiteral>]
                                     Logger.LogF(LogLevel.WildVerbose, fun _ ->  sprintf "ThreadPoolWithWaitHandles:%s, TryExecuteN set HandleDoneExecution" x.ThreadPoolName)
                             else
                                 x.HandleDoneExecution.Reset() |> ignore
-                                Logger.LogF(LogLevel.WildVerbose, fun _ ->  sprintf "ThreadPoolWithWaitHandles:%s, TryExecuteN reset HandleDoneExecution (numThreads = %i)" x.ThreadPoolName numThreads)
+                                let curNumThreads = numThreads
+                                Logger.LogF(LogLevel.WildVerbose, fun _ ->  sprintf "ThreadPoolWithWaitHandles:%s, TryExecuteN reset HandleDoneExecution (numThreads = %i)" x.ThreadPoolName curNumThreads)
                                 let threadID = numThreads - 1
                                 let useAffinityMask = allAffinityMasks.[ threadID % allAffinityMasks.Length ]
                                 let cancelFunc() = 


### PR DESCRIPTION
…s being called

Fix race condition causing NullReferenceException when ReleaseAllItems being called
- Race condition due to ReleaseAllItems releasing Component<'T> member "item" and then Process attempting to do same thing
- Also, includes other fixes / additions
- 1) qsort.cpp compile issue
- 2) Addition of "align" writing routines which make sure that the amount of date written to individual buffer
   in BufferListStream is aligned, so that a call to GetMoreBuffer will return a multiple of the desired alignment unit
- 3) Fix compiler issues in VS 2013 (mutable variables cannot be captured by closures)
