### PR TITLE
When container establishment timed out, throw a timeout exception. 

### DIFF
--- a/src/CoreLib/job.fs
+++ b/src/CoreLib/job.fs
@@ -2554,6 +2554,11 @@ and
                             maxWait := clock.ElapsedTicks + clockFrequency * DeploymentSettings.RemoteContainerEstablishmentTimeoutLimit    
                         elif not jobAction.IsCancelledAndThrow then 
                             Threading.Thread.Sleep(5)
+                    if not bAllSynced && not bFailureToGetSrcMetadata && not jobAction.IsCancelledAndThrow then
+                        // the above loop is exited due to time out
+                        let errorMsg = sprintf "Unable to establish remote containers within %i seconds" (DeploymentSettings.RemoteContainerEstablishmentTimeoutLimit)
+                        Logger.Log( x.JobID, LogLevel.MildVerbose, errorMsg )
+                        raise (TimeoutException(errorMsg))
                 with
                 | :? AggregateException as ex -> 
                     reraise()

--- a/tests/Common/TestEnvironment.fs
+++ b/tests/Common/TestEnvironment.fs
@@ -67,7 +67,7 @@ type TestEnvironment private () =
         sw.Start()
         DeploymentSettings.LocalClusterTraceLevel <- LogLevel.MediumVerbose
         // Sometimes the AppVeyor build VM is really slow on IO and need more time to establish the container
-        DeploymentSettings.RemoteContainerEstablishmentTimeoutLimit <- 120L
+        DeploymentSettings.RemoteContainerEstablishmentTimeoutLimit <- 240L
         let cl =
             if useAppDomainForDaemonsAndContainers then
                 Cluster(sprintf "local[%i]" clusterSize)
@@ -104,7 +104,8 @@ type TestEnvironment private () =
             Prajna.Core.Environment.Cleanup()
             sw.Stop()
             reportProcessStatistics("After environment cleanup")
-            Logger.Log( LogLevel.Info, (sprintf "##### Dispose test environment ..... completed ##### (%i ms)" (sw.ElapsedMilliseconds)))             
+            Logger.Log( LogLevel.Info, (sprintf "##### Dispose test environment ..... completed ##### (%i ms)" (sw.ElapsedMilliseconds)))
+            Thread.Sleep(TimeSpan.FromMinutes(10.0))
             disposed <- true
 
     interface IDisposable with


### PR DESCRIPTION
Also Increase the timeout for unit tests (since AppVeyor VM can sometimes be very slow on IO)
