### PR TITLE
Fix issue with hanging UT caused by ContainerInfo not being first mes…

### DIFF
--- a/src/tools/tools/basenetwork.fs
+++ b/src/tools/tools/basenetwork.fs
@@ -859,13 +859,13 @@ type [<AllowNullLiteral>] Component<'T when 'T:null and 'T:equality>() =
     member private x.CompBase with get() = compBase
 
     member x.ReleaseAllItems() =
-        isTerminated <- true
-        let spinWait = new SpinWait()
-        let oldCnt = x.ProcCount
-        while (x.InProcessing && oldCnt=x.ProcCount) do
-            // if x.ProcCount has increased, then even if InProcessing, then Process has seen "isTerminated=true" condition
-            spinWait.SpinOnce()
         if (Interlocked.CompareExchange(bRelease, 1, 0)=0) then
+            isTerminated <- true
+            let spinWait = new SpinWait()
+            let oldCnt = x.ProcCount
+            while (x.InProcessing && oldCnt=x.ProcCount) do
+                // if x.ProcCount has increased, then even if InProcessing, then Process has seen "isTerminated=true" condition
+                spinWait.SpinOnce()
             let itemDQ : 'T ref = ref Unchecked.defaultof<'T>
             if (Utils.IsNotNull !item) then
                 x.ReleaseItem(item)


### PR DESCRIPTION
…sage sent

Fix issue with hanging UT caused by ContainerInfo not being first message sent
- queue is available to write even if not "connected" (otherwise we would have to
  wait after call to QueueForWriteBetweenContainer)
- ToSend simply appends to queue,
  so ContainerInfo can be immediately "sent" as soon as queue is established, without
  having to wait for connect.
- also move some logic in ReleaseAllItems as it only needs to be executed once
