### PR TITLE
Distributed Function: Registration.

### DIFF
--- a/src/CoreLib/job.fs
+++ b/src/CoreLib/job.fs
@@ -1853,10 +1853,11 @@ and
             stream.Seek( pos, SeekOrigin.Begin ) |> ignore // Reset the pointer in case the stream needs to be read again. 
             bDecodeSuccessful
         with
-        | e -> 
-            let msg = sprintf "DecodeFromBlob: blob %d (%s) failed to be decoded, blob stream is of length %dB, exception %A " blobi blob.Name streamlen e
+        | ex -> 
+            let msg = sprintf "DecodeFromBlob: blob %d (%s) failed to be decoded, blob stream is of length %dB, exception %A " blobi blob.Name streamlen ex
             Logger.Log( LogLevel.Error, msg )
-            failwith msg
+            ex.Data.Add( "DecodeFromBlob", msg)
+            reraise()
             false
     /// Send blob to host, always use non hash version here.  
     member x.SendBlobToHost( queue:NetworkCommandQueue, blobi ) = 


### PR DESCRIPTION
Register a DistributedFunction now return a RegisteredDistributedFunction class. This class provides two interface:
1. Implement IDisposable interface, when disposed, the function is unregistered and no longer respond to the distributed Function call.
1. GetSchemas, which return a 4-tuple that identified the provider, domain, schemaIn and schemaOut of the function registered.

The GetSchemas() can be used to retrieve the signature of the registered DistributedFunction, and allow the function to be accessed agnostically
(e.g., from Prajna Hub, from other language, such as Java, etc.)

JobDependencies.GetInformation( id ) can be used to retrieve the information of the serializer/deserializer. .

Add UnitTest to validate the changes.
