### PR TITLE
Add SafeCTSWrapper Class.

### DIFF
--- a/src/CoreLib/contracts.fs
+++ b/src/CoreLib/contracts.fs
@@ -44,6 +44,7 @@
  ---------------------------------------------------------------------------*)
 namespace Prajna.Service
 open System
+open System.Threading
 open System.IO
 open System.Net
 open System.Collections.Generic
@@ -1111,7 +1112,13 @@ type [<AllowNullLiteral>]
             | _ -> 
                 false
     /// Register Functions ( a set of functions to be called once per queue connected ) 
-
+    member val internal OnConnectOperation = ExecuteEveryTrigger<int64>(LogLevel.MildVerbose) with get
+    /// The action will be called once a queue has been connected
+    member x.OnConnectAction( act:Action<int64>, infoFunc:Func<string> ) = 
+        x.OnConnectOperation.Add( act, infoFunc.Invoke )
+    /// The action will be called once a queue has been connected
+    member x.OnConnect( act:int64 -> unit, infoFunc:unit -> string ) = 
+        x.OnConnectOperation.Add( Action<_>(act), infoFunc )
     member val internal ToBeResolvedServerCollection = ConcurrentQueue<_>() with get
     /// Function that compare if two 
     /// Instantiate a new set of Contract server information from local server. 
@@ -1135,9 +1142,14 @@ type [<AllowNullLiteral>]
         else 
             ContractServerInfoLocal.ContractServerInfoLocalCollection.GetOrAdd( serversInfo.ID, fun _ -> ContractServerInfoLocal(serversInfo) )
     member val internal ResolvedNameCollection = ConcurrentDictionary<_, IPHostEntry >( StringComparer.OrdinalIgnoreCase) with get
-    /// A list of resolved server
+    /// A list of resolved server, ip address to server name 
     member val internal ResolvedServerCollection = ConcurrentDictionary<int64, string >( ) with get
-    member val internal EVDNSResolveProcess = new ManualResetEvent(true) with get 
+    /// A list of resolved server, name to ip addresses
+    /// server name is case insensitive
+    member val internal ResolvedServerNameToIP = ConcurrentDictionary<string, int64 >( StringComparer.OrdinalIgnoreCase ) with get
+    /// A list of connected server 
+    member val internal ConnectedServerCollection = ConcurrentDictionary<int64, bool >( ) with get
+    member val internal CTS = new CancellationTokenSource() with get 
     /// Servers whose information is as part of the cluster
     member val internal ServerInCluster = ConcurrentDictionary<_, bool >( StringComparer.Ordinal) with get
     /// Return each server as a single entry in the cluster. 
@@ -1167,10 +1179,30 @@ type [<AllowNullLiteral>]
     /// and the value is the host name of the server. 
     member x.GetServerCollection() = 
         x.ResolvedServerCollection
+    /// Disconnect a certain channel 
+    member x.DisconnectChannel( sig64: int64 ) = 
+        let bExist, _ = x.ConnectedServerCollection.TryRemove( sig64 )
+        if bExist then 
+            Logger.LogF( LogLevel.MildVerbose, fun _ -> sprintf "ContractServerInfoLocal:Disconnect of channel %A" (LocalDNS.GetHostInfoInt64(sig64)) )
+    /// Add a connected channel. 
+    member x.AddConnectedChannel( ch: NetworkCommandQueue, funcInfo ) = 
+        let sig64 = ch.RemoteEndPointSignature
+        /// We always use signature, to avoid holding reference to NetworkCommandQueue object
+        x.ConnectedServerCollection.GetOrAdd( sig64, true ) |> ignore 
+        x.OnConnectOperation.Trigger( sig64, funcInfo )
+        ch.OnDisconnect.Add( fun _ -> x.DisconnectChannel( sig64 ) )
+    /// Cancel all pending DNS resolve operation
+    member x.Cancel() = 
+        x.CTS.Cancel()
+    /// <summary> 
     /// Resolve: all Single server, 
     /// Resolve: traffic manager once. 
     /// This process is a long running process and may contain blocking operation (DNS resolve), and is recommend to run on its separate thread. 
-    member x.DNSResolveOnce( ) = 
+    /// </summary> 
+    /// <param name="bAutoConnect"> true, automatically connect to the server that is resolved. 
+    ///                             false, no action is done. </param>
+    member x.DNSResolveOnce( bAutoConnect ) = 
+      if not x.CTS.IsCancellationRequested then
         let mutable bResovleAgain = false
         let mutable nTrafficManager = 0 
         let lstServers = List<_>()
@@ -1178,7 +1210,7 @@ type [<AllowNullLiteral>]
         let mutable bEncounterOneTrafficManager = false
         let mutable bEncounterSingleServer = false
         let mutable cnt = x.ToBeResolvedServerCollection.Count
-        while cnt > 0 && x.ToBeResolvedServerCollection.TryDequeue( refValue ) do 
+        while cnt > 0 && x.ToBeResolvedServerCollection.TryDequeue( refValue ) && not x.CTS.IsCancellationRequested do 
             cnt <- cnt - 1
             match !refValue with 
             | TrafficManager ( serverName, port ) -> 
@@ -1204,8 +1236,12 @@ type [<AllowNullLiteral>]
                 bEncounterSingleServer <- true
             | Daemon -> 
                 if RemoteExecutionEnvironment.IsContainer() then 
-                    x.ServerInCluster.GetOrAdd( "", true ) |> ignore 
+                    let channels = NetworkConnections.Current.GetLoopbackChannels()
+                    if bAutoConnect then 
+                        for ch in channels do 
+                            x.AddConnectedChannel( ch, fun _ -> sprintf "ContractServerInfoLocal:Loopback to %A" (LocalDNS.GetShowInfo(ch.RemoteEndPoint)) )
         for tuple in lstServers do 
+          if not x.CTS.IsCancellationRequested then 
             let servername, port = tuple
             try 
                 let entry = 
@@ -1227,10 +1263,11 @@ type [<AllowNullLiteral>]
                     x.ResolvedNameCollection.GetOrAdd( entry.HostName, entry ) |> ignore 
                 if nEntry > 0 then 
                     // The server has been resolved successfully.
-                    let ipv4Addr = entry.AddressList |> Array.choose ( fun ipAddress -> if ipAddress.AddressFamily = Sockets.AddressFamily.InterNetwork then 
-                                                                                            Some (ipAddress.GetAddressBytes())
+                    let addrList = entry.AddressList |> Array.choose ( fun ipAddress -> if ipAddress.AddressFamily = Sockets.AddressFamily.InterNetwork then 
+                                                                                            Some ipAddress
                                                                                         else 
                                                                                             None ) 
+                    let ipv4Addr = addrList |> Array.map ( fun ipAddress -> ipAddress.GetAddressBytes())
                     nEntry <- ipv4Addr.Length
                     if nEntry > 0 then 
                         LocalDNS.AddEntry( entry.HostName, ipv4Addr )
@@ -1242,18 +1279,39 @@ type [<AllowNullLiteral>]
                             else
                                 x.ResolvedServerCollection.GetOrAdd( sig64, entry.HostName) |> ignore 
                                 Logger.LogF( LogLevel.MildVerbose, ( fun _ -> sprintf "Dns name %s(%s) resovled to ipv4 addresses %A ... " servername entry.HostName (IPAddress(addr)) ))
+                    if nEntry > 0 && bAutoConnect then 
+                        let serverEntry = entry.HostName + ":" + port.ToString()
+                        let bExist, oldEntry = x.ResolvedServerNameToIP.TryGetValue( serverEntry )
+                        let bReconnect = 
+                            if not bExist then 
+                                true
+                            else
+                                let sigArray = addrList |> Array.map ( fun ipAddress -> LocalDNS.IPv4AddrToInt64( ipAddress, port) )
+                                not ( sigArray |> Array.exists (fun u -> u=oldEntry ) )
+                        if bExist && bReconnect then 
+                            // Old server entry is mapped to a new address, which doesn't correspond to the old address, the connection should be disconnected 
+                            let ch = NetworkConnections.Current.LookforConnectBySignature( oldEntry )
+                            if Utils.IsNotNull ch then 
+                                // Close the outdated queue
+                                ch.Terminate() 
+                            x.ResolvedServerNameToIP.TryRemove( serverEntry ) |> ignore 
+                        if bReconnect then 
+                            let sig64 = LocalDNS.IPv4AddrToInt64( addrList.[0], port)
+                            x.ResolvedServerNameToIP.Item( serverEntry ) <- sig64
+                            let ch = NetworkConnections.Current.AddConnect( addrList.[0], port )
+                            x.AddConnectedChannel( ch, fun _ -> sprintf "ContractServerInfoLocal to %s" entry.HostName )
                 if nEntry = 0 && not bEncounterTrafficManager then 
                     Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "Dns name %s (%s) resovled to zerosyn ipv4 addresses ... " servername entry.HostName ))
             with
             | e -> 
                 Logger.LogF( LogLevel.Info, ( fun _ -> sprintf "!!! Exception !!! when try to resolve dns name %s ... %A " servername e ))
         if bResovleAgain then 
-            x.DNSResolveOnce()
+            x.DNSResolveOnce(bAutoConnect)
         else
-            if nTrafficManager >= 0 && not (x.EVDNSResolveProcess.WaitOne(0)) then 
-                let bStatus = x.EVDNSResolveProcess.WaitOne( x.InternalToResolveAllInMillisecond / nTrafficManager ) 
+            if nTrafficManager >= 0 && not (x.CTS.IsCancellationRequested) then 
+                let bStatus = x.CTS.Token.WaitHandle.WaitOne( x.InternalToResolveAllInMillisecond / nTrafficManager ) 
                 if not bStatus then 
-                    x.DNSResolveOnce()
+                    x.DNSResolveOnce(bAutoConnect)
 
 
 /// ContractServerInfoLocalRepeatable is used to host remote servers that requires repeatable DNS resolution. 
@@ -1263,17 +1321,16 @@ type [<AllowNullLiteral>]
     inherit ContractServerInfoLocal() 
     member val private RepeatedDNSResolveInProccess = ref 0 with get
     /// Start a continuous DNS resolve process, because DNS resolve has blocking operation, the process is placed on its own thread, rather than schedule on a timer or task 
-    member x.RepeatedDNSResolve() = 
+    member x.RepeatedDNSResolve(bAutoConnect) = 
         if Interlocked.CompareExchange( x.RepeatedDNSResolveInProccess, 1, 0) = 0 then 
-            if not (x.EVDNSResolveProcess.WaitOne(0)) then 
+            if not (x.CTS.IsCancellationRequested) then 
                 // Remove all objects in the Concurrent Queue
                 let refObj = ref Unchecked.defaultof<_>
                 while ( x.ToBeResolvedServerCollection.TryDequeue( refObj ) ) do
                     ()
                 for entry in x.ServerCollection do 
                     x.ToBeResolvedServerCollection.Enqueue( entry )
-                x.EVDNSResolveProcess.Reset() |> ignore 
-                let thread = ThreadTracking.StartThreadForFunctionWithCancelation( fun _ -> x.EVDNSResolveProcess.Set() |> ignore ) ( x.ToString ) x.DNSResolveOnce 
+                let thread = ThreadTracking.StartThreadForFunctionWithCancelation( fun _ -> x.CTS.Cancel() ) ( x.ToString ) ( fun _ -> x.DNSResolveOnce(bAutoConnect) )
                 ()
 
 /// Specify additional contract servers to be used. 
@@ -1338,7 +1395,7 @@ type [<AllowNullLiteral>]
 
 /// <summary>
 /// ContractStoreAtProgram contains wrapped up contract and deserialization code for other program/service to access the contract. The class is to be used by Prajna 
-/// core programmers.  
+/// core programmers. 
 /// </summary>
 type internal ContractStoreAtProgram() = 
     /// <summary>

--- a/src/ServiceLib/BasicService/monitorservice.fs
+++ b/src/ServiceLib/BasicService/monitorservice.fs
@@ -265,7 +265,7 @@ type MonitorInstance< 'StartParamType
         let mutable cntCur = 0 
         while not (x.EvTerminated.WaitOne(0)) do 
             // Resolve for server, if there is any 
-            x.ServerInfo.DNSResolveOnce()
+            x.ServerInfo.DNSResolveOnce(false)
             let col = x.ServerInfo.GetServerCollection()
             for pair in col do
                 x.MonitoredServers.GetOrAdd( pair.Key, fun _ -> OneServerPerformance(pair.Key, pair.Value) ) |> ignore 

--- a/src/tools/tools/process.fs
+++ b/src/tools/tools/process.fs
@@ -2443,7 +2443,7 @@ type internal SingleCreation<'U>() =
 type internal SafeCTSWrapper(t:TimeSpan) as thisInstance = 
     let refCount = ref 0 
     let refDisposed = ref 0 
-    let ctsRef = ref ( new CancellationTokenSource(t) ) 
+    let ctsRef = ref ( if t = TimeSpan.MaxValue then new CancellationTokenSource() else new CancellationTokenSource(t) ) 
     let cancellationRegistration = (!ctsRef).Token.Register(Action(thisInstance.DecrementAndCheckForDisposeCTS ) )
     /// Initializes a new instance of the SafeCTSWrapper class.
     new () = 

--- a/src/tools/tools/process.fs
+++ b/src/tools/tools/process.fs
@@ -2436,3 +2436,90 @@ type internal SingleCreation<'U>() =
             if bLockTaken then 
                 lock.Exit() 
 
+/// A safe wrapper for CancellationTokenSource, for the secure disposale of CancellationTokenSource object. 
+/// When the SafeCTSWrapper is cancelled, the associated CancellationTokenSource is cancelled, and 
+/// after all jobs exit, the CancellationTokenSource will be disposed. 
+/// SafeCTSWrapper is not mean to be disposed itself, as that will cause .Token property to fails. 
+type internal SafeCTSWrapper(t:TimeSpan) as thisInstance = 
+    let refCount = ref 0 
+    let refDisposed = ref 0 
+    let ctsRef = ref ( new CancellationTokenSource(t) ) 
+    let cancellationRegistration = (!ctsRef).Token.Register(Action(thisInstance.DecrementAndCheckForDisposeCTS ) )
+    /// Initializes a new instance of the SafeCTSWrapper class.
+    new () = 
+        new SafeCTSWrapper(TimeSpan.MaxValue)
+    /// Initializes a new instance of the CancellationTokenSource class that will be canceled after the specified delay in milliseconds.
+    new (delayInMS) = 
+        new SafeCTSWrapper(TimeSpan(0,0,0,delayInMS))
+    /// For Testing purpose only, has the CTS structure been disposed?
+    member x.IsDisposed with get() = let cts = Volatile.Read( ctsRef ) 
+                                     Utils.IsNull cts
+    /// Gets whether cancellation has been requested
+    member x.Token with get() = let cts = Volatile.Read( ctsRef ) 
+                                if Utils.IsNotNull cts && not cts.IsCancellationRequested then 
+                                    let cnt = Interlocked.Increment( refCount )
+                                    if cnt > 0 && not cts.IsCancellationRequested  then 
+                                        new SafeCTSToken( x, cts.Token )
+                                    else
+                                        let cnt = Interlocked.Increment( refCount )
+                                        if cnt < 0 then 
+                                            x.DisposeCTS() 
+                                        null
+                                else
+                                    null
+    /// Communicates a request for cancellation.
+     member x.Cancel() = 
+        let cts = Volatile.Read( ctsRef ) 
+        if Utils.IsNotNull cts then 
+            cts.Cancel() 
+    /// Communicates a request for cancellation, and specifies whether remaining callbacks and cancelable operations should be processed.
+    member x.Cancel(throwOnFirstException:bool) = 
+        let cts = Volatile.Read( ctsRef ) 
+        if Utils.IsNotNull cts then 
+            cts.Cancel(throwOnFirstException) 
+    /// Schedules a cancel operation on this CancellationTokenSource after the specified number of milliseconds.
+    member x.CancelAfter(delayInMS:int) = 
+        let cts = Volatile.Read( ctsRef ) 
+        if Utils.IsNotNull cts then 
+            cts.CancelAfter(delayInMS) 
+    /// Schedules a cancel operation on this CancellationTokenSource after the specified number of milliseconds.
+    member x.CancelAfter(delayTime:TimeSpan) = 
+        let cts = Volatile.Read( ctsRef ) 
+        if Utils.IsNotNull cts then 
+            cts.CancelAfter(delayTime) 
+    /// Decrement and check for DisposeCTS
+    member x.DecrementAndCheckForDisposeCTS() = 
+        let cnt = Interlocked.Decrement( refCount )
+        if cnt < 0 then 
+            x.DisposeCTS() 
+    member x.DisposeCTS() = 
+        if Interlocked.Increment( refDisposed ) = 1 then 
+            let ctsValue = !ctsRef
+            let cts = Interlocked.CompareExchange( ctsRef, null, ctsValue )
+            if Object.ReferenceEquals( cts, ctsValue ) then 
+                cts.Dispose() 
+            cancellationRegistration.Dispose()
+/// A cancellation Token which is the dual of SafeCTSWrapper
+and [<AllowNullLiteral>] 
+    internal SafeCTSToken( holder:SafeCTSWrapper, token: CancellationToken ) = 
+    member x.IsCancellationRequested = token.IsCancellationRequested
+    member x.CanBeCanceled = token.CanBeCanceled
+    member x.WaitHandle = token.WaitHandle
+    member x.Register(callback:Action) = token.Register( callback )
+    member x.Register(callback:Action,useSynchronizationContext:bool) = token.Register(callback,useSynchronizationContext)
+    member x.Register(callback:Action<Object>,state:Object) = token.Register(callback,state)
+    member x.Register(callback:Action<Object>,state:Object,useSynchronizationContext:bool) = token.Register(callback,state,useSynchronizationContext)
+    member x.ThrowIfCancellationRequested() = token.ThrowIfCancellationRequested()
+    member x.Disposing(disposing) =
+        holder.DecrementAndCheckForDisposeCTS()
+    interface IDisposable with
+        override x.Dispose() =
+            x.Disposing(true)
+            GC.SuppressFinalize(x)
+
+    override x.Finalize() =
+        x.Disposing(false)
+
+
+
+


### PR DESCRIPTION
Add SafeCTSWrapper Class, which is a container for CancellationTokenSource(). SafeCTSWrapper allows CancellationTokenSource to be
safely released after:
1. Cancel() is called.
2. All jobs that uses CancellationTokenSource/CancellationToken has exited.

UnitTest added to validate the resource release of SafeCTSWrapper .

Add continuous DNS resolving.
