### PR TITLE
Fix issue caused by early disposal of MemoryStreamB

### DIFF
--- a/samples/DistributedWebCrawler/DistributedWebCrawler.fs
+++ b/samples/DistributedWebCrawler/DistributedWebCrawler.fs
@@ -110,7 +110,6 @@ let main orgargs =
     let downloadLimit = parse.ParseInt( "-download", -1 )
     let nMaxWait = parse.ParseInt( "-maxwait", 30000 )
     let bRetrieve = parse.ParseBoolean( "-retrieve", false )
-    let bTask = parse.ParseBoolean( "-task", false )
     let downloadChunk = parse.ParseInt( "-downloadChunk", (1<<<20) )
     let countTag = parse.ParseInt( "-countTag", 0 )
     let countWords = parse.ParseInt( "-countWord", 0 )

--- a/src/CoreLib/DSeq.fs
+++ b/src/CoreLib/DSeq.fs
@@ -975,6 +975,7 @@ and [<AllowNullLiteral>]
         /// SourceStream: the current DStream doesn't depend on other DSet, it is a source 
         | SinkStream ->
             x.SyncPreWrite jbInfo parti meta streamObject
+            (streamObject :> IDisposable).Dispose()
     /// Push down operation
     member private x.SyncExecuteDownstreamImpl jbInfo parti meta o = 
         match x.DependencyDownstream with 
@@ -995,11 +996,9 @@ and [<AllowNullLiteral>]
                     // Async network queue is used 
                     if not bClusterReplicate then
                             x.SyncSendPeer jbInfo parti meta o peeri 
-                            match o with
-                            | :? StreamBase<byte> as ms -> (ms :> IDisposable).Dispose()
-                            | _ -> ()
-                        // We don't flush network queue (as the network queue are multiplexed), the execution queue will be flushed at close stream. 
-                        // x.SendPeer jbInfo parti meta o peeri 
+            match o with
+            | :? StreamBase<byte> as ms -> (ms :> IDisposable).Dispose()
+            | _ -> ()
         | PassTo childS
         | SendToNetwork childS -> 
             let childStream = childS.TargetStream
@@ -1018,8 +1017,6 @@ and [<AllowNullLiteral>]
                 match o with
                 | :? StreamBase<byte> as ms -> (ms :> IDisposable).Dispose()
                 | _ -> ()
-                    // We don't flush network queue (as the network queue are multiplexed), the execution queue will be flushed at close stream. 
-                    // x.SendPeer jbInfo parti meta o peeri 
                 ()
         | MulticastToNetwork childS -> 
             let childStream = childS.TargetStream
@@ -1046,6 +1043,7 @@ and [<AllowNullLiteral>]
 //            let msg = sprintf "IterateExecuteDownstream, DecodeTo hasn't been implemented in DStream "
 //            Logger.Log(LogLevel.Error, msg) 
 //            failwith msg 
+
     member internal x.SyncPreWrite jbInfo parti meta streamObject = 
         if Utils.IsNull streamObject then 
             let writeMeta = x.CountFunc.GetMetadataForPartition( meta, parti, 0 )
@@ -1057,7 +1055,7 @@ and [<AllowNullLiteral>]
             msPrefix.WriteInt64( meta.Serial )
             msPrefix.WriteVInt32( meta.NumElems ) 
             ms.InsertBefore(msPrefix) |> ignore
-            (ms :> IDisposable).Dispose()
+            // don't dispose ms here as caller will still need it
             let msCombine = msPrefix
             let writeMeta = x.CountFunc.GetMetadataForPartition( meta, parti, meta.NumElems )
             x.SyncWriteChunk jbInfo parti writeMeta msCombine
@@ -1073,6 +1071,7 @@ and [<AllowNullLiteral>]
 //                dobj.Parent.IterateHasCompletedAllDownstreamTask() 
 //            | SinkStream -> 
 //                true
+
     /// Process feedback of the outgoing command. 
     member internal x.ProcessCallback( cmd:ControllerCommand, peeri:int, ms:StreamBase<byte>, jobID:Guid ) =
         try

--- a/src/Toolkit/ClusterInfo/Program.fs
+++ b/src/Toolkit/ClusterInfo/Program.fs
@@ -1,6 +1,7 @@
 // Learn more about F# at http://fsharp.net
 // See the 'F# Tutorial' project for more help.
 open System
+open System.IO
 open Prajna.Tools
 open Prajna.Tools.FSharp
 open Prajna.Tools.StringTools
@@ -10,6 +11,8 @@ open System.Text.RegularExpressions
 
 [<EntryPoint>]
 let main argv = 
+    MemoryStreamB.InitSharedPool()
+
     let parse = ArgumentParser(argv)
     let outputClusterFile = parse.ParseString( "-outcluster", "" )
     let inputClusterFiles = parse.ParseStrings( "-incluster", [||] )
@@ -91,7 +94,16 @@ let main argv =
                                 Some(Array.sub info.ListOfClients start (stop-start+1)))
             |> Seq.concat
             |> Seq.toArray
-        clusterInfo.Save(outputClusterFile)
+        if (File.Exists outputClusterFile) then
+            Console.Write("File {0} exists, overwrite:", outputClusterFile)
+            let resp = Console.ReadLine()
+            if (resp.ToLower().[0] = 'y') then
+                File.Delete(outputClusterFile)
+                clusterInfo.Save(outputClusterFile)
+            else
+                Console.WriteLine("File exists, not saving")
+        else
+            clusterInfo.Save(outputClusterFile)
 
     0 // return an integer exit code
 

--- a/tests/tools/tools/serialize.fs
+++ b/tests/tools/tools/serialize.fs
@@ -52,6 +52,7 @@ module SerializationTests =
     let testExplicitLayoutArray() = 
         let mutable p1 = new Point()
         p1.Rho <- 1.0f
+        let p1 = p1
         testObject <| Array.concat (Array.init 5 (fun _ -> [|p1; new Point()|]))
         
     [<Test>]


### PR DESCRIPTION
Fix issue in download test using DistributedWebCrawler caused by early disposal of MemoryStreamB object.
