### PR TITLE
Non-Serializable, circular C# closures, perf, tests

### DIFF
--- a/Prajna.sln
+++ b/Prajna.sln
@@ -150,6 +150,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "qsort", "samples\SortBenchm
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SortBenchmark", "SortBenchmark", "{9DDC2A59-C4D8-4DDE-B82E-A37DF325F109}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpTests", "tests\CSharpTests\CSharpTests.csproj", "{6797EE77-90E4-4719-BC81-F3FA2840CA9A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -572,6 +574,18 @@ Global
 		{E95D819A-B8E3-4F94-B7EE-300E31AB0181}.Release|Win32.Build.0 = Release|Win32
 		{E95D819A-B8E3-4F94-B7EE-300E31AB0181}.Release|x64.ActiveCfg = Release|x64
 		{E95D819A-B8E3-4F94-B7EE-300E31AB0181}.Release|x64.Build.0 = Release|x64
+		{6797EE77-90E4-4719-BC81-F3FA2840CA9A}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{6797EE77-90E4-4719-BC81-F3FA2840CA9A}.Debug|Mixed Platforms.ActiveCfg = Debug|x64
+		{6797EE77-90E4-4719-BC81-F3FA2840CA9A}.Debug|Mixed Platforms.Build.0 = Debug|x64
+		{6797EE77-90E4-4719-BC81-F3FA2840CA9A}.Debug|Win32.ActiveCfg = Debug|x64
+		{6797EE77-90E4-4719-BC81-F3FA2840CA9A}.Debug|x64.ActiveCfg = Debug|x64
+		{6797EE77-90E4-4719-BC81-F3FA2840CA9A}.Debug|x64.Build.0 = Debug|x64
+		{6797EE77-90E4-4719-BC81-F3FA2840CA9A}.Release|Any CPU.ActiveCfg = Release|x64
+		{6797EE77-90E4-4719-BC81-F3FA2840CA9A}.Release|Mixed Platforms.ActiveCfg = Release|x64
+		{6797EE77-90E4-4719-BC81-F3FA2840CA9A}.Release|Mixed Platforms.Build.0 = Release|x64
+		{6797EE77-90E4-4719-BC81-F3FA2840CA9A}.Release|Win32.ActiveCfg = Release|x64
+		{6797EE77-90E4-4719-BC81-F3FA2840CA9A}.Release|x64.ActiveCfg = Release|x64
+		{6797EE77-90E4-4719-BC81-F3FA2840CA9A}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -625,5 +639,6 @@ Global
 		{24176C7F-6562-4D88-80C9-56A5DD4C431D} = {012ABB28-19FD-4935-AB0B-9E34D8B93D92}
 		{E95D819A-B8E3-4F94-B7EE-300E31AB0181} = {9DDC2A59-C4D8-4DDE-B82E-A37DF325F109}
 		{9DDC2A59-C4D8-4DDE-B82E-A37DF325F109} = {9AC1211D-ED52-415B-ABD1-B28390DB0BCC}
+		{6797EE77-90E4-4719-BC81-F3FA2840CA9A} = {ED8079DD-2B06-4030-9F0F-DC548F98E1C4}
 	EndGlobalSection
 EndGlobal

--- a/build.fsx
+++ b/build.fsx
@@ -400,6 +400,7 @@ let runTests (target:string) =
         !! pattern
         |> NUnit (fun p ->
             { p with
+                ExcludeCategory = "Performance"
                 DisableShadowCopy = true
                 ProcessModel = SeparateProcessModel
                 Domain = SingleDomainModel

--- a/src/tools/tools/customserialize.fs
+++ b/src/tools/tools/customserialize.fs
@@ -308,7 +308,7 @@ and private CustomizedSerializationSurrogate(nameObj, encoder, decoder, getNewMs
 
 // The serialization surrogate selector that selects CSharpDisplayClassSerializationSurrogate for C# compiler generated display class. 
 // It implements ISurrogateSelector
-and private CustomizedSerializationSurrogateSelector(getNewMs : unit->MemoryStream, getNewMsWithBuf : byte[]*int*int*bool*bool->MemoryStream) =
+and internal CustomizedSerializationSurrogateSelector(getNewMs : unit->MemoryStream, getNewMsWithBuf : byte[]*int*int*bool*bool->MemoryStream) =
     let mutable nextSelector = Unchecked.defaultof<ISurrogateSelector> 
 
     interface ISurrogateSelector with

--- a/tests/CSharpTests/CSharpSerializationTests.cs
+++ b/tests/CSharpTests/CSharpSerializationTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Prajna.Core;
+using Prajna.Tools;
+using Prajna.Tools.Tests;
+
+namespace CSharpTests
+{
+    [TestClass]
+    public class CSharpSerializationTests
+    {
+        [TestMethod]
+        public void CircularCSharpClosure()
+        {
+            object[] arr = new object[] { 1, 2, 3 };
+            Func<object[]> getArray = () => arr;
+            arr[2] = getArray;
+            foreach (var streamConstructors in SerializationTests.MemoryStreamConstructors)
+            {
+                var otherGetArray = (Func<object[]>) SerializationTests.roundTrip(streamConstructors.Item1, streamConstructors.Item2, getArray);
+                var otherGetArrayCircularRef = (Func<object[]>)(otherGetArray()[2]);
+                Assert.AreEqual(getArray()[0], otherGetArray()[0]);
+                Assert.AreEqual(getArray()[0], otherGetArrayCircularRef()[0]);
+                Assert.AreSame(otherGetArray(), otherGetArrayCircularRef());
+            }
+        }
+    }
+}

--- a/tests/CSharpTests/CSharpTests.csproj
+++ b/tests/CSharpTests/CSharpTests.csproj
@@ -1,0 +1,99 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
+    <ProjectGuid>{6797EE77-90E4-4719-BC81-F3FA2840CA9A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CSharpTests</RootNamespace>
+    <AssemblyName>CSharpTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debugx64\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\Releasex64\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="CSharpSerializationTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CoreLib\CoreLib.fsproj">
+      <Project>{b4a6b9fa-a35b-4adb-ac15-6cca66225921}</Project>
+      <Name>CoreLib</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\tools\tools\Tools.fsproj">
+      <Project>{159bb552-8346-4313-8e10-43b88beca63b}</Project>
+      <Name>Tools</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\tools\tools\Tools.Tests.fsproj">
+      <Project>{963abc6f-f1df-4408-8e6c-4e6631adc873}</Project>
+      <Name>Tools.Tests</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/CSharpTests/Properties/AssemblyInfo.cs
+++ b/tests/CSharpTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CSharpTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CSharpTests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6797ee77-90e4-4719-bc81-f3fa2840ca9a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/tools/tools/serialize.fs
+++ b/tests/tools/tools/serialize.fs
@@ -3,9 +3,9 @@
 namespace Prajna.Tools.Tests
 
 open System
-open System.Linq
-open System.Collections.Generic
 open System.Runtime.Serialization
+open System.Diagnostics
+open System.Collections.Generic
 open System.Runtime.InteropServices
 open System.IO
 
@@ -16,18 +16,24 @@ open Prajna.Tools
 [<TestFixture(Description = "Tests for serialization")>]
 module SerializationTests =
 
-    let CreateMemoryStreams() : seq<MemoryStream > = 
-        do BufferListStream<byte>.InitSharedPool()
-        seq {yield upcast new MemoryStreamB(); yield new MemoryStream()}
+    type MemoryStreamConstructors = (unit -> MemoryStream) * ((byte[] * int * int * bool * bool) -> MemoryStream)
 
-    let roundTrip (stream: MemoryStream) (obj: obj) = 
-        let formatter = new BinarySerializer() :> IFormatter
+    do BufferListStream<byte>.InitSharedPool()
+    let memStreamBConstructors : MemoryStreamConstructors = (fun () -> upcast new MemoryStreamB()), (fun (a,b,c,d,e) -> upcast new MemoryStreamB(a,b,c,d,e))
+    let memStreamDotNetConstructors = (fun () -> new MemoryStream()), (fun (a,b,c,d,e) -> new MemoryStream(a,b,c,d,e))
+
+    let MemoryStreamConstructors =  [| memStreamBConstructors; memStreamDotNetConstructors|]
+
+    let roundTrip (streamConstructors: MemoryStreamConstructors) (obj: obj) = 
+        let emptyConstructor = fst streamConstructors
+        let stream = emptyConstructor()
+        let formatter = GenericSerialization.GetDefaultFormatter( CustomizedSerializationSurrogateSelector(streamConstructors) )
         formatter.Serialize(stream, obj)
         stream.Position <- 0L
         formatter.Deserialize(stream)
         
     let testObject (obj: obj) = 
-        for ms in CreateMemoryStreams() do
+        for ms in MemoryStreamConstructors do
             Assert.AreEqual(obj, roundTrip ms obj)
 
     [<Test>]
@@ -96,7 +102,7 @@ module SerializationTests =
         let name = "foo"
         let ps = [|PersonStruct(name, 1); PersonStruct(name, 2)|]
         testObject ps
-        for ms in CreateMemoryStreams() do
+        for ms in MemoryStreamConstructors do
             let other = roundTrip ms ps :?> PersonStruct[]
             Assert.AreSame(ps.[0].Name, ps.[1].Name) // of course
             Assert.AreEqual(ps.[0].Name, other.[0].Name) // equals survives serialization ...
@@ -123,7 +129,7 @@ module SerializationTests =
     let testCyclicSelf() = 
         let cyclicValue = Cyclic(Value = 0, Next = null)
         cyclicValue.Next <- cyclicValue
-        for ms in CreateMemoryStreams() do
+        for ms in MemoryStreamConstructors do
             let other = roundTrip ms cyclicValue :?> Cyclic
             Assert.AreEqual(cyclicValue.Value, other.Value)
             Assert.AreEqual(other.Next, other)
@@ -132,7 +138,7 @@ module SerializationTests =
     let testCyclicDirect() = 
         let cyclicValue = Cyclic(Value = 0, Next = Cyclic(Value = 1, Next = null))
         cyclicValue.Next.Next <- cyclicValue
-        for ms in CreateMemoryStreams() do
+        for ms in MemoryStreamConstructors do
             let other = roundTrip ms cyclicValue :?> Cyclic
             Assert.AreEqual(cyclicValue.Value, other.Value)
             Assert.AreEqual(cyclicValue.Next.Value, other.Next.Value)
@@ -142,7 +148,7 @@ module SerializationTests =
     let testCyclicIndirect() = 
         let cyclicValue = Cyclic(Value = 0, Next = Cyclic(Value = 1, Next = Cyclic(Value = 2, Next = null)))
         cyclicValue.Next.Next.Next <- cyclicValue
-        for ms in CreateMemoryStreams() do
+        for ms in MemoryStreamConstructors do
             let other = roundTrip ms cyclicValue :?> Cyclic
             Assert.AreEqual(cyclicValue.Value, other.Value)
             Assert.AreEqual(cyclicValue.Next.Value, other.Next.Value)
@@ -160,7 +166,7 @@ module SerializationTests =
         let cur = ref 0
         let next() = let ret = !cur in cur := ret + 1; ret
         do next() |> ignore; next()|> ignore; next()|> ignore
-        for ms in CreateMemoryStreams() do
+        for ms in MemoryStreamConstructors do
             let other = roundTrip ms next :?> (unit -> int)
             Assert.AreEqual(Array.init 3 (ignoreArg next), Array.init 3 (ignoreArg other))
 
@@ -169,7 +175,7 @@ module SerializationTests =
         let cur = ref 0
         let next() = let ret = !cur in cur := ret + 1; ret
         do next() |> ignore; next()|> ignore; next()|> ignore
-        for ms in CreateMemoryStreams() do
+        for ms in MemoryStreamConstructors do
             let other = roundTrip ms next :?> (unit -> int)
             cur := !cur + 1
             Assert.AreNotEqual(Array.init 3 (ignoreArg next), Array.init 3 (ignoreArg other))
@@ -187,7 +193,7 @@ module SerializationTests =
         let dict = new Dictionary<string, obj>()
         dict.Add("a", 1)
         dict.Add("0", dict)
-        for ms in CreateMemoryStreams() do
+        for ms in MemoryStreamConstructors do
             let other = roundTrip ms dict :?> Dictionary<string, obj>
             Assert.AreEqual(dict.["a"], other.["a"])
             Assert.IsTrue( Object.ReferenceEquals( other, other.["0"] ) )
@@ -198,7 +204,7 @@ module SerializationTests =
         let dict2 = new Dictionary<string, obj>()
         dict1.Add("2", dict2)
         dict2.Add("1", dict1)
-        for ms in CreateMemoryStreams() do
+        for ms in MemoryStreamConstructors do
             let other = roundTrip ms dict1 :?> Dictionary<string, obj>
             Assert.IsTrue( Object.ReferenceEquals( other, (other.["2"] :?> Dictionary<string, obj>).["1"]  ) )
 
@@ -253,7 +259,7 @@ module SerializationTests =
     [<Test>]
     let testKitchenSink() = 
         let ks = createKitchenSinkArray().[0]
-        for ms in CreateMemoryStreams() do
+        for ms in MemoryStreamConstructors do
             let other = roundTrip ms ks :?> KitchenSink
             Assert.IsTrue <|
                 Seq.forall2 (fun (ks1: KitchenSink) ks2 -> ks1.NonRecursiveEquals(ks2)) (ks.Traverse()) (other.Traverse()) 
@@ -268,7 +274,7 @@ module SerializationTests =
         let kitchenSinkArr = createKitchenSinkArray()
         os.SS0 <- new KitchenSink(Name = "Eric", Parents = kitchenSinkArr)
         os.SS <- kitchenSinkArr
-        for ms in CreateMemoryStreams() do
+        for ms in MemoryStreamConstructors do
             let other = roundTrip ms os :?> OtherStuff
             Assert.AreEqual(os.Complex, other.Complex)
             Assert.AreEqual(os.Complexes, other.Complexes)
@@ -291,4 +297,95 @@ module SerializationTests =
     let testNonSerializable() = 
         testObject <| MyType()
         
+    let timeRoundTrip (name: string) (formatter: IFormatter) (stream: MemoryStream) obj =
+        GC.Collect()
+        let sw = Stopwatch.StartNew()
+        do formatter.Serialize(stream, obj)
+        let serTime = sw.Elapsed
+        stream.Position <- 0L
+        sw.Restart()
+        let ret = formatter.Deserialize(stream) 
+        let deserTime = sw.Elapsed
+        serTime, deserTime
+
+    let memStreamConstructors = memStreamBConstructors
+    let noArgConstructor = fst memStreamBConstructors
+
+    let compareRoundTripTimes : int -> obj -> TimeSpan * TimeSpan = 
+        let selector = CustomizedSerializationSurrogateSelector(memStreamConstructors)
+        let prajnaFormatter = GenericSerialization.GetFormatter(GenericSerialization.PrajnaFormatterGuid, selector)
+        let binaryFormatter = GenericSerialization.GetFormatter(GenericSerialization.BinaryFormatterGuid, selector)
+        fun numRepeats obj ->
+            let accPair (f,s) (f2,s2) = f + f2, s + s2
+            let sumTimePairs = Seq.fold accPair (TimeSpan.Zero, TimeSpan.Zero)
+            let binarySer,binaryDeser = [for i in 1..numRepeats -> timeRoundTrip "Binary" binaryFormatter (noArgConstructor()) obj] |> sumTimePairs
+            let prajnaSer,prajnaDeser = [for i in 1..numRepeats -> timeRoundTrip "Prajna" prajnaFormatter (noArgConstructor()) obj] |> sumTimePairs
+            Console.WriteLine(sprintf "Prajna: %A, %A, %A" prajnaSer prajnaDeser (prajnaSer + prajnaDeser))
+            Console.WriteLine(sprintf "Binary: %A, %A, %A" binarySer binaryDeser (binarySer + binaryDeser))
+            (prajnaSer + prajnaDeser), (binarySer + binaryDeser)
     
+    [<Test>]
+    [<Category("Performance")>]
+    let SerPerfMatrix() =
+        printfn "Square Matrix"
+        let r = new Random()
+        let A : float[,] = Array2D.init 5000 5000 (fun _ _ -> r.NextDouble() |> float)
+        let prajnaTime, binaryTime = compareRoundTripTimes 1 A
+        Assert.IsTrue(prajnaTime.TotalMilliseconds < binaryTime.TotalMilliseconds)
+        
+    [<Test>]
+    [<Category("Performance")>]
+    let SerPerfRank3Tensor() =
+        printfn "Cube Tensor"
+        let r = new Random()
+        let A : float[,,] = Array3D.init 300 300 300 (fun _ _ _ -> r.NextDouble() |> float)
+        let prajnaTime, binaryTime = compareRoundTripTimes 1 A
+        Assert.IsTrue(prajnaTime.TotalMilliseconds < binaryTime.TotalMilliseconds)
+        
+    let createRandomJaggedMatrix rows cols = 
+        let r = new Random()
+        Array.init rows (fun _ -> Array.init cols (fun _ -> r.NextDouble() |> float))
+
+    let baseSize = 5000
+    
+    [<Test>]
+    [<Category("Performance")>]
+    let SerPerfJaggedArrayA_VeryWide() =
+        printfn "Very Wide Jagged"
+        let A = createRandomJaggedMatrix (baseSize / 100) (baseSize * 100) 
+        let prajnaTime, binaryTime = compareRoundTripTimes 60 A
+        Assert.IsTrue(prajnaTime.TotalMilliseconds < binaryTime.TotalMilliseconds)
+        
+    [<Test>]
+    [<Category("Performance")>]
+    let SerPerfJaggedArrayB_Wide() =
+        printfn "Wide Jagged"
+        let A = createRandomJaggedMatrix (baseSize / 10) (baseSize * 10) 
+        let prajnaTime, binaryTime = compareRoundTripTimes 60 A
+        Assert.IsTrue(prajnaTime.TotalMilliseconds < binaryTime.TotalMilliseconds)
+        
+    [<Test>]
+    [<Category("Performance")>]
+    let SerPerfJaggedArrayC_Square() =
+        printfn "Square Jagged"
+        let A = createRandomJaggedMatrix baseSize baseSize
+        let prajnaTime, binaryTime = compareRoundTripTimes 20 A
+        Assert.IsTrue(prajnaTime.TotalMilliseconds < binaryTime.TotalMilliseconds)
+        
+    [<Test>]
+    [<Category("Performance")>]
+    let SerPerfJaggedArrayD_Tall() =
+        printfn "Tall Jagged"
+        let A = createRandomJaggedMatrix (baseSize * 10) (baseSize / 10)
+        let prajnaTime, binaryTime = compareRoundTripTimes 20 A
+        Assert.IsTrue(prajnaTime.TotalMilliseconds < binaryTime.TotalMilliseconds)
+        
+    [<Test>]
+    [<Category("Performance")>]
+    let SerPerfJaggedArrayE_VeryTall() =
+        printfn "Very Tall Jagged"
+        let A = createRandomJaggedMatrix (baseSize * 100) (baseSize / 100)
+        let prajnaTime, binaryTime = compareRoundTripTimes 1 A
+        Assert.IsTrue(prajnaTime.TotalMilliseconds < binaryTime.TotalMilliseconds)
+        
+


### PR DESCRIPTION
- Adding support for classes not marked as [Serializable] for Portable Class Library compatibility, with test
- Adding support for circular C# closures, which use circular IObjectReferences (BinaryFormatter will error-out on these, we can't fix with SurrogateSelector unfortunately)
- Specialized code for common zero-based, 1D arrays, for common-case speed
- New perf tests comparing BinarySerializer and PrajnaSerializer
- Modifying tests to run with both MemoryStreamB and standard .Net MemoryStream
