### PR TITLE
Fix the lazy init pattern

### DIFF
--- a/src/CoreLib/GV.fs
+++ b/src/CoreLib/GV.fs
@@ -327,36 +327,42 @@ and /// Information of Within Job cluster information.
         x.CurPeerIndex
 
     member x.QueueForWriteBetweenContainer( peeri ) =
-        let queue = x.LinkedCluster.Queues.[peeri]
-        if Utils.IsNull queue then
-            try 
-                let ndInfo = x.NodesInfo.[peeri] 
-                if Utils.IsNull ndInfo then 
-                    null
-                else
-                    let queue = 
-                        match ndInfo.NodeType with 
-                        | NodeWithInJobType.TCPOnly -> 
-                            Logger.LogF( LogLevel.MildVerbose, (fun _ -> sprintf "Attempt to connect to %s:%d as peer %d" x.LinkedCluster.Nodes.[peeri].MachineName ndInfo.ListeningPort peeri ))
-                            Cluster.Connects.AddConnect( x.LinkedCluster.Nodes.[peeri].MachineName, ndInfo.ListeningPort )
-                        | _ -> 
-                            Logger.Fail( sprintf "ClusterJobInfo.QueueForWriteBetweenContainer, in cluster %s:%s, unknown node type %A for peer %d to connect to" 
-                                            x.LinkedCluster.Name x.LinkedCluster.VersionString ndInfo.NodeType peeri )
-                    x.LinkedCluster.PeerIndexFromEndpoint.[queue.RemoteEndPoint] <- peeri
-                    queue.GetOrAddRecvProc ("ClusterParseHost", Cluster.ParseHostCommand queue peeri) |> ignore
-                    // even though queue has not yet been "connected", ToSend still works as it only queues data
-                    use ms = new MemStream(1024)
-                    ms.WriteString( x.LinkedCluster.Name )
-                    ms.WriteInt64( x.LinkedCluster.Version.Ticks )
-                    ms.WriteVInt32( x.CurPeerIndex )
-                    queue.ToSendNonBlock( ControllerCommand( ControllerVerb.ContainerInfo, ControllerNoun.ClusterInfo ), ms )
-                    x.LinkedCluster.Queues.[peeri] <- queue
-                    queue
-            with 
-            | e -> 
-                Logger.Fail( sprintf "ClusterJobInfo.QueueForWriteBetweenContainer fails with exception %A" e )
+        let peerQueue = x.LinkedCluster.Queues.[peeri]
+        if Utils.IsNull peerQueue then
+            lock (x.LinkedCluster) (fun _ ->
+                try 
+                    let queue = x.LinkedCluster.Queues.[peeri]
+                    if Utils.IsNull queue then
+                        let ndInfo = x.NodesInfo.[peeri] 
+                        if Utils.IsNull ndInfo then 
+                            null
+                        else
+                            let queue = 
+                                match ndInfo.NodeType with 
+                                | NodeWithInJobType.TCPOnly -> 
+                                    Logger.LogF( LogLevel.MildVerbose, (fun _ -> sprintf "Attempt to connect to %s:%d as peer %d" x.LinkedCluster.Nodes.[peeri].MachineName ndInfo.ListeningPort peeri ))
+                                    Cluster.Connects.AddConnect( x.LinkedCluster.Nodes.[peeri].MachineName, ndInfo.ListeningPort )
+                                | _ -> 
+                                    Logger.Fail( sprintf "ClusterJobInfo.QueueForWriteBetweenContainer, in cluster %s:%s, unknown node type %A for peer %d to connect to" 
+                                                    x.LinkedCluster.Name x.LinkedCluster.VersionString ndInfo.NodeType peeri )
+                            x.LinkedCluster.PeerIndexFromEndpoint.[queue.RemoteEndPoint] <- peeri
+                            queue.GetOrAddRecvProc ("ClusterParseHost", Cluster.ParseHostCommand queue peeri) |> ignore
+                            // even though queue has not yet been "connected", ToSend still works as it only queues data
+                            use ms = new MemStream(1024)
+                            ms.WriteString( x.LinkedCluster.Name )
+                            ms.WriteInt64( x.LinkedCluster.Version.Ticks )
+                            ms.WriteVInt32( x.CurPeerIndex )
+                            queue.ToSendNonBlock( ControllerCommand( ControllerVerb.ContainerInfo, ControllerNoun.ClusterInfo ), ms )
+                            x.LinkedCluster.Queues.[peeri] <- queue
+                            queue
+                      else
+                          queue
+                with 
+                | e -> 
+                    Logger.Fail( sprintf "ClusterJobInfo.QueueForWriteBetweenContainer fails with exception %A" e )
+        )
         else
-            queue
+            peerQueue
 
     member x.Queue( peeri ) = 
         x.LinkedCluster.Queues.[peeri]
@@ -1651,7 +1657,6 @@ and [<AllowNullLiteral>]
                                 x.NumActiveConnections <- x.NumActiveConnections + 1        
                                 x.bConnected.[peeri] <- true
                                 queue.Initialize()
-                    x.Cluster.QueuesInitialized := 1
                     // This is the one thread that will win the race, the other thread will spin to wait for initialization      
                     x.bNetworkInitialized <- true
                     Logger.LogF( LogLevel.WildVerbose, ( fun _ -> sprintf "Setup network for %A %s:%s" x.ParamType x.Name x.VersionString ) )

--- a/src/CoreLib/builtinfunction.fs
+++ b/src/CoreLib/builtinfunction.fs
@@ -54,14 +54,11 @@ type internal DistributedFunctionBuiltIn() =
 
  /// Initialization of the Distributed function execution environment. 
 type internal DistributedFunctionEnvironment() = 
-    static let nInitialized = ref 0 
-    static member private InitOnce() = 
+    static let init = lazy (
         let builtInProvider = DistributedFunctionBuiltInProvider()
         DistributedFunctionStore.Current.RegisterProvider( builtInProvider )
         DistributedFunctionStore.Current.RegisterFunction<_>( DistributedFunctionBuiltIn.GetContainerFunctionName, DistributedFunctionBuiltIn.GetContainerLocal ) |> ignore
         DistributedFunctionStore.Current.NullifyProvider( )
+    )
     static member Init () =
-        if !nInitialized = 0 then 
-            if Interlocked.Increment(nInitialized) = 1 then 
-                DistributedFunctionEnvironment.InitOnce()    
-        ()
+        init.Force()

--- a/src/CoreLib/environment.fs
+++ b/src/CoreLib/environment.fs
@@ -37,18 +37,17 @@ open Prajna.Service
 
 /// Represent Prajna Environment for running Prajna program
 type Environment() =
-    static let nInitialized = ref 0 
+    static let init = lazy(
+        Cluster.SetCreateLocalCluster(LocalCluster.Create)
+        DistributedFunctionEnvironment.Init()
+    )
 
     /// Initialize Prajna Environment for running Prajna program
     /// Currently, under the following scenario, Environment.Init() should be called explicitly by users:
     /// 1）Local cluster is used
     /// 2) Distributed function is used. 
     static member Init () = 
-        /// Avoid using Interlocked.Increment if this has already been initialized. 
-        if !nInitialized = 0 then 
-            if Interlocked.Increment( nInitialized ) = 1 then 
-                Cluster.SetCreateLocalCluster(LocalCluster.Create)
-                DistributedFunctionEnvironment.Init()       
+        init.Force()
 
     /// Cleanup Prajna Environment for running Prajna program
     static member Cleanup() =

--- a/src/CoreLib/function.fs
+++ b/src/CoreLib/function.fs
@@ -1272,24 +1272,11 @@ type internal DepositFunctionWrapper<'U0, 'U>() as x =
     inherit MetaFunction<'U>()
     do 
         x.DepositFunc <- x.DepositBlob
-    member val BufferInitialized = ref 0 with get
-    member val DepositBuffer = null with get, set
-    member x.DepositOneReset() = 
-        x.BufferInitialized := 0
-        x.DepositBuffer <- null       
-    member x.DepositOneInitAll() = 
-        if Utils.IsNull x.DepositBuffer then 
-            if Interlocked.CompareExchange( x.BufferInitialized, 1, 0 )=0 then 
-                x.DepositBuffer <- ConcurrentDictionary<_,_>()
-                true
-            else
-                false
-        else
-            false
+    member val DepositBuffer = ConcurrentDictionary<_,_>() with get
     override x.Reset() = 
-        x.DepositOneReset()
+        ()
     override x.InitAll() = 
-        x.DepositOneInitAll() |> ignore
+        ()
     member internal x.DepositBlob parenti (meta, o:Object ) = 
         let uArray = if Utils.IsNull o then null else ( CastFunction<'U0>.CastTo o )
         x.DepositBuffer.Item( parenti ) <- ( meta, uArray )
@@ -1342,18 +1329,12 @@ type internal CrossJoinFoldFunctionWrapper<'U0,'U1,'U,'S>(mapFunc: 'U0->'U1->'U,
         x.DepositFunc <- x.DepositBlobForFold
         x.MapFunc <- x.CrossJoinFoldInnerMapFunc
         x.ExecuteFunc <- x.ExecuteFoldFunc
-    member val StateBuffer = null with get, set
+    member val StateBuffer = ConcurrentDictionary<_,_>() with get
     member val FoldMapTo = MapToKind.OBJECT with get, set
     override x.Reset() = 
-        x.StateBuffer <- null
-        x.DepositOneReset()
+        ()
     override x.InitAll() = 
-        if x.DepositOneInitAll() then 
-            x.StateBuffer <- ConcurrentDictionary<_,_>()
-        else
-            while Utils.IsNull x.StateBuffer do
-                // Spinning to wait for the StateBuffer to be initialized by other threads
-                ()
+        ()
     member internal x.DepositBlobForFold parenti (meta, o:Object ) = 
         let uArray = if Utils.IsNull o then null else ( CastFunction<'U0>.CastTo o )
         x.DepositBuffer.Item( parenti ) <- ( meta, uArray )

--- a/tests/CoreLib/DSet.fs
+++ b/tests/CoreLib/DSet.fs
@@ -1641,7 +1641,6 @@ type DSetTests () =
             Assert.AreEqual( sum, test*10 )
 
     [<Test(Description = "Repro for Issue 106")>]
-    [<Ignore("A known issue that should be fixed")>] // Remove Ignore when the bug is fixed
     member x.DSetIssue106ReproTest() =
         let numPartitions = 4
         let guid = Guid.NewGuid().ToString("D")


### PR DESCRIPTION
The original lazy init pattern (using CAS) in some places are not correctly. Replace them with "lazy" etc.  The "release" pattern is also problematic but not covered in this change. 

There are still issues with the following two tests that need to be investigated. 
- Prajna.Core.Tests.DSetTests.DSetMapSeqTakeTest
- Prajna.Core.Tests.DSetTests.DSetMapConcurrentTest
