### PR TITLE
Clean up of cleanup logic which sometimes throws exceptions

### DIFF
--- a/src/CoreLib/contracts.fs
+++ b/src/CoreLib/contracts.fs
@@ -1297,7 +1297,7 @@ type [<AllowNullLiteral>]
                             let ch = NetworkConnections.Current.LookforConnectBySignature( oldEntry )
                             if Utils.IsNotNull ch then 
                                 // Close the outdated queue
-                                ch.Terminate() 
+                                ch.Close()
                             x.ResolvedServerNameToIP.TryRemove( serverEntry ) |> ignore 
                         if bReconnect then 
                             let sig64 = LocalDNS.IPv4AddrToInt64( addrList.[0], port)

--- a/src/ServiceLib/Gateway/frontend.fs
+++ b/src/ServiceLib/Gateway/frontend.fs
@@ -555,7 +555,7 @@ type FrontEndInstance< 'StartParamType
             let remoteSignature = pair.Key
             let queue = Cluster.Connects.LookforConnectBySignature( remoteSignature ) 
             if not (Utils.IsNull queue ) then 
-                queue.Terminate()
+                queue.Close()
         x.EvPrimaryQueue.Set() |> ignore 
         if not(Utils.IsNull x.TimerBufferCache) then 
             x.TimerBufferCache.Cancel() 

--- a/src/ServiceLib/ServiceEndpoint/backend.fs
+++ b/src/ServiceLib/ServiceEndpoint/backend.fs
@@ -565,7 +565,7 @@ type BackEndInstance< 'StartParamType
             let remoteSignature = pair.Key
             let queue = Cluster.Connects.LookforConnectBySignature( remoteSignature ) 
             if not (Utils.IsNull queue ) then 
-                queue.Terminate()
+                queue.Close()
         x.EvPrimaryQueue.Set() |> ignore 
     /// Parse Receiving command 
     member internal x.ParseFrontEndRequest queue cmd ms = 

--- a/src/tools/tools/process.fs
+++ b/src/tools/tools/process.fs
@@ -254,9 +254,14 @@ type internal CleanUp private () =
         let allKeys = cleanUpStore.Keys |> Seq.sort |> Seq.toArray
         for key in allKeys do 
             let bExist, oneCleanUp = cleanUpStore.TryRemove( key )
+            let sw = new Stopwatch()
             if bExist then 
-                Logger.LogF( LogLevel.ExtremeVerbose, ( fun _ -> sprintf "::: Enter to clean up %s" (oneCleanUp.InfoFunc()) ))
-                oneCleanUp.CleanUpFunc();
+                Logger.LogF( LogLevel.ExtremeVerbose, ( fun _ -> sprintf "::: Enter to clean up %s" ((oneCleanUp.InfoFunc())) ))
+                sw.Restart()
+                oneCleanUp.CleanUpFunc()
+                Logger.LogF(LogLevel.Info, (fun _ -> sprintf "Cleanup %s takes %d ms" (oneCleanUp.InfoFunc()) sw.ElapsedMilliseconds))
+                //Console.WriteLine("Cleanup {0} takes {1} ms", (oneCleanUp.InfoFunc()), sw.Elapsed.Milliseconds)
+                //Logger.LogF( LogLevel.MildVerbose, ( fun _ -> sprintf "::: Done clean up %s" (oneCleanUp.InfoFunc()) ))
         x.FlushAllListeners()
 
 module internal Process =

--- a/tests/ExtraTest/CleanUpTest/CleanUpTest/Program.cs
+++ b/tests/ExtraTest/CleanUpTest/CleanUpTest/Program.cs
@@ -38,7 +38,14 @@ namespace PrajnaTest.CS
 
         static void Main(string[] args)
         {
-            Logger.ParseArgs(args);
+            var parse = new Prajna.Tools.ArgumentParser(args);
+            var clusterFile = parse.ParseString("-cluster", "cluster.lst");
+            //Logger.ParseArgs(args);
+
+            //string[] local = new string[2] {"a.bin", "b.bin"};
+            //JobDependencies.Current.Add(local);
+            //var localRemote = new Tuple<string, string>(@"c:\sort\raw\raw.bin", "a.bin");
+            //JobDependencies.Current.AddLocalRemote(localRemote);
 
             Console.WriteLine("Init...");
             Prajna.Core.Environment.Init();
@@ -46,7 +53,7 @@ namespace PrajnaTest.CS
             Prajna.Core.Environment.EnableLoggingOnDNS();
             Console.WriteLine("Init done.");
 
-            //var cluster = new Cluster("cluster.lst");
+            //var cluster = new Cluster(clusterFile);
             var cluster = new Cluster("local[1]");
             var nodes = cluster.Nodes;
             Console.WriteLine($"nodes = {cluster.NumNodes}");


### PR DESCRIPTION
- Single codepath for cleanup which is the following order:
  1) GenericNetwork.CloseSocket (via either network termination or explicit call to Close)
  2) NetworkCommandQueue.OnSocketClose which calls NetworkCommandQueue.ConnectionClose
  3) Component termination
  4) Disposal of resources
